### PR TITLE
 Added a simple initial VSCode workspace config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,8 @@ tests/**/spec_*/
 !docs/_code/**/*.surf.ron
 
 # Code Editors/IDEs
+*.code-workspace
 .vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/tasks.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	"recommendations": [
+		"ms-python.python",
+		"ms-python.flake8",
+		"ms-python.vscode-pylance",
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+	// !IMPORTANT NOTE!
+	// All user-specific changes should live in a local `.code-workspace` file
+	"flake8.args": [
+		"--config", "${workspaceFolder}/contrib/.flake8"
+	],
+
+	"python.testing.cwd": "${workspaceFolder}/build",
+	"python.testing.autoTestDiscoverOnSaveEnabled": false,
+	"python.testing.unittestArgs": [
+		"discover",
+		"-v",
+		"-s",
+		".."
+	],
+	"python.testing.pytestEnabled": false,
+	"python.testing.unittestEnabled": true,
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Test (With Nox)",
+			"group": "test",
+			"type": "process",
+			"command": "python",
+			"args": [
+				"-m", "nox",
+				"-s", "test"
+			],
+			"problemMatcher": "$python"
+		},
+		{
+			"label": "Lint (With Nox)",
+			"group": "test",
+			"type": "process",
+			"command": "python",
+			"args": [
+				"-m", "nox",
+				"-s", "lint"
+			],
+			"problemMatcher": "$python"
+		},
+	]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR is another simple/small one, it just adds a basic setup for a VSCode workspace that should be suited to working with Torii.

It adds two tasks, one to test with nox and one to lint with nox, as well as some suggested extensions, and finally it sets up the integrated testing support in VSCode to work well with Torii and the flake8 linter to point to the configuration file correctly

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii Boards [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii Boards and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md#ai-usage-policy
