### PR TITLE
Cleanup: Fix flake8/lints, add Ruff to lint check, and normalize board formatting

### DIFF
--- a/contrib/.flake8
+++ b/contrib/.flake8
@@ -1,35 +1,20 @@
 [flake8]
-
-exclude =
-	.git,
-	__pycache__,
-	.eggs,
-	build,
-	_build,
-	deps
-
 max-line-length = 120
 indent-size = 1
 statistics = True
+# NOTE(aki):
+# Comments are not allowed in the ignore block, see the `[tool.ruff.lint]` section in `pyproject.toml`
+# for what each lint is
 ignore =
-	E124,
 	E126,
-	E128,
-	E131,
 	E201,
 	E202,
-	E203,
 	E221,
-	E226,
 	E241,
 	E251,
 	E261,
-	E262,
 	E272,
 	E302,
 	E305,
-	E401,
-	E402,
-	F405,
 	W191,
 	W504

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,11 +114,14 @@ def typecheck_pyright(session: Session) -> None:
 @nox.session(reuse_venv = True)
 def lint(session: nox.Session) -> None:
 	session.install('flake8')
+	session.install('ruff')
 
 	session.run(
 		'flake8', '--config', str((CNTRB_DIR / '.flake8').resolve()),
 		'./torii_boards', './tests', './docs'
 	)
+	session.run('ruff', 'check', './torii_boards', './tests', './docs')
+
 
 @nox.session(reuse_venv = True)
 def dist(session: Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,26 @@ line-ending = 'lf'
 # Due to Ruff being stupid and not letting us use `'''` we have to use this
 quote-style = 'preserve'
 
+[tool.ruff.lint]
+select = ['E', 'F', 'W']
+# NOTE(aki):
+# Commented out ignores are not supported by Ruff but are by Flake8,
+# they are present in `contrib/.flake8`.
+ignore = [
+	# 'E126', # Continuation line over-indented for hanging indent
+	'E201', # Whitespace after '('
+	'E202', # Whitespace before ')'
+	'E221', # Multiple spaces before operator
+	'E241', # Multiple spaces after ','
+	'E251', # Unexpected spaces around keyword / parameter equals
+	'E261', # At least two spaces before inline comment
+	'E272', # Multiple spaces before keyword
+	'E302', # Expected 2 blank lines, found n
+	'E305', # Expected 2 blank lines after end of function or class
+	'W191', # Indentation contains tabs
+	# 'W504', # line break after binary operator
+]
+
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = 'single'
 inline-quotes  = 'single'

--- a/torii_boards/altera/cyclone_iii/de0.py
+++ b/torii_boards/altera/cyclone_iii/de0.py
@@ -41,30 +41,34 @@ class DE0Platform(AlteraPlatform):
 			pins = 'J6 H5 H6 G4 G5 J7 H7 E3 E4 D2',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'E11', b = 'F11', c = 'H12', d = 'H13', e = 'G12', f = 'F12', g = 'F13', dp = 'D13', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(1,
+		Display7SegResource(
+			1,
 			a = 'A13', b = 'B13', c = 'C13', d = 'A14', e = 'B14', f = 'E14', g = 'A15', dp = 'B15', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(2,
+		Display7SegResource(
+			2,
 			a = 'D15', b = 'A16', c = 'B16', d = 'E15', e = 'A17', f = 'B17', g = 'F14', dp = 'A18', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(3,
+		Display7SegResource(
+			3,
 			a = 'B18', b = 'F15', c = 'A19', d = 'B19', e = 'C19', f = 'D19', g = 'G15', dp = 'G16', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'U22', tx = 'U21', rts = 'V22', cts = 'V21',
 			attrs = Attrs(io_standard = '3.3-V LVTTL'),
 			role = 'dce'
 		),
-
-		Resource('display_hd44780', 0,
+		Resource(
+			'display_hd44780', 0,
 			Subsignal('e', Pins('E21', dir = 'o')),
 			Subsignal('d', Pins('D22 D21 C22 C21 B22 B21 D20 C20', dir = 'io')),
 			Subsignal('rw', Pins('E22', dir = 'o')),
@@ -73,35 +77,36 @@ class DE0Platform(AlteraPlatform):
 			Subsignal('bl', Pins('F21', dir = 'o')),
 			Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = 'H19 H17 H20 H21',
 			g = 'H22 J17 K17 J21',
 			b = 'K22 K21 J22 K18',
 			hs = 'L21', vs = 'L22',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		PS2Resource(0, # Keyboard
+		PS2Resource(
+			0, # Keyboard
 			clk = 'P22', dat = 'P21', attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		PS2Resource(1, # Mouse
+		PS2Resource(
+			1, # Mouse
 			clk = 'R21', dat = 'R22', attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'Y21', cmd = 'Y22', dat0 = 'AA22', dat3 = 'W21', wp_n = 'W20',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = 'E5', cke = 'E6', cs_n = 'G7', we_n = 'D6', ras_n = 'F7', cas_n = 'G8',
 			ba = 'B5 A4', a = 'C4 A3 B3 C3 A5 C6 B6 A6 C7 B7 B4 A7 C8',
 			dq = 'D10 G10 H10 E9 F9 G9 H9 F8 A8 B9 A9 C10 B10 A10 E10 F10', dqm = 'E7 B8',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		*NORFlashResources(0,
+		*NORFlashResources(
+			0,
 			rst = 'R1', byte_n = 'AA1',
 			cs_n = 'N8', oe_n = 'R6', we_n = 'P4', wp_n = 'T3', by = 'M7',
 			a = 'P7 P5 P6 N7 N5 N6 M8 M4 P2 N2 N1 M3 M2 M1 L7 L6 AA2 M5 M6 P1 P3 R2',
@@ -110,13 +115,15 @@ class DE0Platform(AlteraPlatform):
 		),
 	]
 	connectors  = [
-		Connector('j', 4,
+		Connector(
+			'j', 4,
 			'AB12 AB16 AA12 AA16 AA15 AB15 AA14 AB14 AB13 AA13 -    -    '
 			'AB10 AA10 AB8  AA8  AB5  AA5  AB3  AB4  AA3  AA4  V14  U14  '
 			'Y13  W13  U13  V12  -    -    R10  V11  Y10  W10  T8   V8   '
 			'W7   W6   V5   U7   -    -    -    -    -    -    -    -    '
 		),
-		Connector('j', 5,
+		Connector(
+			'j', 5,
 			'AB11 AA20 AA11 AB20 AA19 AB19 AB18 AA18 AA17 AB17 -    -    '
 			'Y17  W17  U15  T15  W15  V15  R16  AB9  T16  AA9  AA7  AB7  '
 			'T14  R14  U12  T12  -    -    R11  R12  U10  T10  U9   T9   '

--- a/torii_boards/altera/cyclone_iv/rz_easyfpga_a2_2.py
+++ b/torii_boards/altera/cyclone_iv/rz_easyfpga_a2_2.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
+
 from torii.build                  import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
 from torii.build.run              import BuildProducts
 from torii.hdl.ir                 import Fragment
 from torii.platform.resources     import (
-	ButtonResources, Display7SegResource, I2CResource, LEDResources, PS2Resource, SDRAMResource, UARTResource, VGAResource
+	ButtonResources, Display7SegResource, I2CResource, LEDResources, PS2Resource, SDRAMResource, UARTResource,
+	VGAResource
 )
 from torii.platform.vendor.altera import AlteraPlatform
 
@@ -27,96 +30,91 @@ class RZEasyFPGAA2_2Platform(AlteraPlatform):
 		Resource(
 			'clk50', 0, Pins('23', dir = 'i'), Clock(50e6), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Reset switch, located on the lower left of the board.
 		Resource('rst', 0, PinsN('25', dir = 'i'), Attrs(io_standard = '3.3-V LVTTL')),
-
 		# LEDs, located on the bottom of the board.
 		*LEDResources(
 			pins = '87 86 85 84', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Buttons, located on the bottom of the board, right of the LEDs.
 		*ButtonResources(
 			pins = '88 89 90 91', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Connections to the SKHynix RAM chip on board.
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = '43', cs_n = '72', we_n = '69', ras_n = '71', cas_n = '70',
 			ba = '73 74', a = '76 77 80 83 68 67 66 65 64 60 75 59',
 			dq = '28 30 31 32 33 34 38 39 54 53 52 51 50 49 46 44',
 			dqm = '42 55', attrs = Attrs(io_standard = '3.3-V LVCMOS')
 		),
-
 		# VGA connector, located on the right of the board.
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = '106', g = '105', b = '104',
 			hs = '101', vs = '103'
 		),
-
 		# 4 digit 7 segment display, located on top of the board.
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = '128', b = '121', c = '125', d = '129', e = '132', f = '126', g = '124', dp = '127',
 			invert = True
 		),
-
-		Resource('display_7seg_ctrl', 0,
+		Resource(
+			'display_7seg_ctrl', 0,
 			Subsignal('en', Pins('133 135 136 137', dir = 'o', invert = True)),
 		),
-
 		# PS2 port, located on upper right of the board.
 		PS2Resource(0, clk = '119', dat = '120'),
-
 		# LM75 temperature sensor
 		I2CResource(0, scl = '112', sda = '113'),
-
 		# AT24C08 EEPROM
-		I2CResource(1, scl = '99' , sda = '98' ),
-
+		I2CResource(1, scl = '99', sda = '98'),
 		# Buzzer
 		Resource('buzzer', 0, PinsN('110', dir = 'o')),
-
 		# Serial port, located above the VGA port.
 		UARTResource(0, tx = '114', rx = '115'),
-
 		# LCD connector, located above the 7 segment display.
-		Resource('lcd_hd44780', 0,
+		Resource(
+			'lcd_hd44780', 0,
 			Subsignal('rs', Pins('141', dir = 'o')),
 			Subsignal('rw', Pins('138', dir = 'o')),
-			Subsignal('e' , Pins('143', dir = 'o')),
-			Subsignal('d' , Pins('142 1 144 3 2 10 7 11', dir = 'io')),
+			Subsignal('e', Pins('143', dir = 'o')),
+			Subsignal('d', Pins('142 1 144 3 2 10 7 11', dir = 'io')),
 		),
-
 		# IR receiver, located right of the buttons.
-		Resource('cir', 0,
+		Resource(
+			'cir', 0,
 			Subsignal('rx', Pins('100', dir = 'i'))
 		),
 	]
 
 	connectors  = [
 		# Located above the chip.
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'-   -   11  7   2   144 142 138 136 133 129 127 125 121 119 114 112 110 -  '
-			'-   -   24  10  3   1   143 141 137 135 132 128 126 124 120 115 113 111 -  '),
-
+			'-   -   24  10  3   1   143 141 137 135 132 128 126 124 120 115 113 111 -  '
+		),
 		# Located right of the chip.
-		Connector('gpio', 1,
-			'-   -  '
-			'106 105'
-			'104 103'
-			'101 100'
-			'99  98 '
-			'91  90 '
-			'89  88 '
-			'87  86 '
-			'85  84 '
-			'-   -  '),
-
+		Connector(
+			'gpio', 1,
+			'-   -   '
+			'106 105 '
+			'104 103 '
+			'101 100 '
+			'99  98  '
+			'91  90  '
+			'89  88  '
+			'87  86  '
+			'85  84  '
+			'-   -   '
+		),
 		# Located below the chip.
-		Connector('gpio', 2,
+		Connector(
+			'gpio', 2,
 			'30 32 34 39 43 46 50 52 54 58 60 65 67 71 73 75 77 83 -  -  - '
 			'28 31 33 38 42 44 51 53 55 59 64 66 68 70 72 74 76 80 -  -  - '
 		),
@@ -124,10 +122,9 @@ class RZEasyFPGAA2_2Platform(AlteraPlatform):
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs):
 		overrides = {
-			'add_settings':
-				r'''
+			'add_settings': dedent('''
 				set_global_assignment -name CYCLONEII_RESERVE_NCEO_AFTER_CONFIGURATION 'USE AS REGULAR IO'
-				'''
+			''')
 		}
 		return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 

--- a/torii_boards/altera/cyclone_v/chameleon96.py
+++ b/torii_boards/altera/cyclone_v/chameleon96.py
@@ -24,52 +24,52 @@ class Chameleon96Platform(AlteraPlatform):
 			pins = 'Y19 Y20',
 			attrs = Attrs(io_standard = '2.5 V')
 		),
-
 		# TDA19988 HDMI transmitter
-		Resource('tda19988', 0,
-			Subsignal('vpa',       Pins('    W8  W7  V6  V5  U6 ', dir = 'o')), # bits 3 to 7
-			Subsignal('vpb',       Pins('AB5 AA5 AA8 AB8 AB9 Y11', dir = 'o')), # bits 2 to 7
-			Subsignal('vpc',       Pins('    W6  Y5  AB7 AA7 AA6', dir = 'o')), # bits 3 to 7
-			Subsignal('pclk',      Pins('AB10', dir = 'o')),
-			Subsignal('hsync',     Pins('V10 ', dir = 'o')),
-			Subsignal('vsync',     Pins('V7  ', dir = 'o')),
-			Subsignal('de',        Pins('Y8  ', dir = 'o')),
+		Resource(
+			'tda19988', 0,
+			Subsignal('vpa', Pins('W8 W7 V6 V5 U6', dir = 'o')), # bits 3 to 7
+			Subsignal('vpb', Pins('AB5 AA5 AA8 AB8 AB9 Y11', dir = 'o')), # bits 2 to 7
+			Subsignal('vpc', Pins('W6 Y5 AB7 AA7 AA6', dir = 'o')), # bits 3 to 7
+			Subsignal('pclk', Pins('AB10', dir = 'o')),
+			Subsignal('hsync', Pins('V10', dir = 'o')),
+			Subsignal('vsync', Pins('V7', dir = 'o')),
+			Subsignal('de', Pins('Y8', dir = 'o')),
 			Attrs(io_standard = '1.8 V')
 		),
-
-		I2CResource('tda19988_i2c', 0,
+		I2CResource(
+			'tda19988_i2c', 0,
 			scl = 'U7', sda = 'U10',
 			attrs = Attrs(io_standard = '1.8 V'),
 		),
-
-		Resource('tda19988_i2s', 0,
-			Subsignal('mclk',  Pins('V11 ', dir = 'o')), # OSC_IN/AP3
-			Subsignal('txd',   Pins('AA11', dir = 'o')), # AP1
-			Subsignal('txc',   Pins('W11 ', dir = 'o')), # ACLK
-			Subsignal('txfs',  Pins('V9  ', dir = 'o')), # AP0
+		Resource(
+			'tda19988_i2s', 0,
+			Subsignal('mclk', Pins('V11', dir = 'o')), # OSC_IN/AP3
+			Subsignal('txd', Pins('AA11', dir = 'o')), # AP1
+			Subsignal('txc', Pins('W11', dir = 'o')), # ACLK
+			Subsignal('txfs', Pins('V9', dir = 'o')), # AP0
 			Attrs(io_standard = '1.8 V')
 		),
-
 		# Wifi and BT module
-		*SDCardResources('wifi', 0,
+		*SDCardResources(
+			'wifi', 0,
 			clk = 'AB20', cmd = 'AB18', dat0 = 'Y14', dat1 = 'AB19', dat2 = 'AA18', dat3 = 'AB15',
 			attrs = Attrs(io_standard = '1.8 V'),
 		),
-
-		Resource('bt', 0,
+		Resource(
+			'bt', 0,
 			Subsignal('host_wake', Pins('AB12', dir = 'o')),
 			Attrs(io_standard = '1.8 V'),
 		),
-
-		Resource('bt_i2s', 0,
-			Subsignal('txd',   Pins('Y15 ', dir = 'o')), # BT_PCM_IN
-			Subsignal('rxd',   Pins('Y16 ', dir = 'i')), # BT_PCM_OUT
-			Subsignal('txc',   Pins('AA13', dir = 'i')), # BT_PCM_CLK
-			Subsignal('txfs',  Pins('AB13', dir = 'i')), # BT_PCM_SYNC
+		Resource(
+			'bt_i2s', 0,
+			Subsignal('txd', Pins('Y15', dir = 'o')), # BT_PCM_IN
+			Subsignal('rxd', Pins('Y16', dir = 'i')), # BT_PCM_OUT
+			Subsignal('txc', Pins('AA13', dir = 'i')), # BT_PCM_CLK
+			Subsignal('txfs', Pins('AB13', dir = 'i')), # BT_PCM_SYNC
 			Attrs(io_standard = '1.8 V'),
 		),
-
-		UARTResource('bt_uart', 0,
+		UARTResource(
+			'bt_uart', 0,
 			rx = 'AB14', cts = 'AB17', tx = 'AA15', rts = 'AA16', role = 'dte',
 			attrs = Attrs(io_standard = '1.8 V'),
 		),
@@ -77,21 +77,22 @@ class Chameleon96Platform(AlteraPlatform):
 
 	connectors  = [
 		# J3, 2x20 expansion port
-		Connector('J', 3,
-			'-      -      Y13    -      W14    -      C5     -      C6     -'
-			'-      -      -      -      -      E5     -      F5     -      A6'
-			'-      A5     -      -      -      -      -      -      -      -'
-			'-      -      -      -      -      -      -      -      -      -'
+		Connector(
+			'J', 3,
+			'-   -   Y13 -   W14 -   C5  -   C6  -  '
+			'-   -   -   -   -   E5  -   F5  -   A6 '
+			'-   A5  -   -   -   -   -   -   -   -  '
+			'-   -   -   -   -   -   -   -   -   -  '
 		),
-
 		# J8, 2x30 high speed expansion port (MIPI CSI)
-		Connector('J', 8,
-			'-      V16    -      U17    -      -      -      V17    -      W18'
-			'-      -      -      U18    W12    V19    -      -      -      -'
-			'-      -      -      -      -      -      -      -      -      -'
-			'-      -      -      -      -      -      -      -      -      -'
-			'-      -      -      -      -      -      -      -      -      -'
-			'-      -      -      -      -      -      -      -      -      -'
+		Connector(
+			'J', 8,
+			'-   V16 -   U17 -   -   -   V17 -   W18 '
+			'-   -   -   U18 W12 V19 -   -   -   -   '
+			'-   -   -   -   -   -   -   -   -   -   '
+			'-   -   -   -   -   -   -   -   -   -   '
+			'-   -   -   -   -   -   -   -   -   -   '
+			'-   -   -   -   -   -   -   -   -   -   '
 		),
 	]
 

--- a/torii_boards/altera/cyclone_v/de0_cv.py
+++ b/torii_boards/altera/cyclone_v/de0_cv.py
@@ -47,51 +47,59 @@ class DE0CVPlatform(AlteraPlatform):
 			pins = 'U13 V13 T13 T12 AA15 AB15 AA14 AA13 AB13 AB12',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'U21', b = 'V21', c = 'W22', d = 'W21', e = 'Y22', f = 'Y21', g = 'AA22', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(1,
+		Display7SegResource(
+			1,
 			a = 'AA20', b = 'AB20', c = 'AA19', d = 'AA18', e = 'AB18', f = 'AA17', g = 'U22', invert = True,
-			attrs = Attrs(io_standard = '3.3-V LVTTL')),
-		Display7SegResource(2,
+			attrs = Attrs(io_standard = '3.3-V LVTTL')
+		),
+		Display7SegResource(
+			2,
 			a = 'Y19', b = 'AB17', c = 'AA10', d = 'Y14', e = 'V14', f = 'AB22', g = 'AB21', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(3,
+		Display7SegResource(
+			3,
 			a = 'Y16', b = 'W16', c = 'Y17', d = 'V16', e = 'U17', f = 'V18', g = 'V19', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(4,
+		Display7SegResource(
+			4,
 			a = 'U20', b = 'Y20', c = 'V20', d = 'U16', e = 'U15', f = 'Y15', g = 'P9', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(5,
+		Display7SegResource(
+			5,
 			a = 'N9', b = 'M8', c = 'T14', d = 'P14', e = 'C1', f = 'C2', g = 'W19', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = 'A9 B10 C9 A5',
 			g = 'L7 K7 J7 J8',
 			b = 'B6 B7 A8 A7',
 			hs = 'H8', vs = 'G8',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		PS2Resource(0, # Keyboard
+		PS2Resource(
+			0, # Keyboard
 			clk = 'D3', dat = 'G2', attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		PS2Resource(1, # Mouse
+		PS2Resource(
+			1, # Mouse
 			clk = 'E2', dat = 'G1', attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'H11', cmd = 'B11', dat0 = 'K9', dat1 = 'D12', dat2 = 'E12', dat3 = 'C11',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = 'AB11', cke = 'R6', cs_n = 'U6', we_n = 'AB5', ras_n = 'AB6', cas_n = 'V6',
 			ba = 'T7 AB7', a = 'W8 T8 U11 Y10 N6 AB10 P12 P7 P8 R5 U8 P6 R7',
 			dq = 'Y9 T10 R9 Y11 R10 R11 R12 AA12 AA9 AB8 AA8 AA7 V10 V9 U10 T9', dqm = 'U12 N8',
@@ -99,17 +107,19 @@ class DE0CVPlatform(AlteraPlatform):
 		),
 	]
 	connectors  = [
-		Connector('j', 1,
-			'N16  B16  M16  C16  D17  K20  K21  K22  M20  M21  '
-			'-    -    N21  R22  R21  T22  N20  N19  M22  P19  '
-			'L22  P17  P16  M18  L18  L17  L19  K17  -    -    '
-			'K19  P18  R15  R17  R16  T20  T19  T18  T17  T15  '
+		Connector(
+			'j', 1,
+			'N16 B16 M16 C16 D17 K20 K21 K22 M20 M21 '
+			'-   -   N21 R22 R21 T22 N20 N19 M22 P19 '
+			'L22 P17 P16 M18 L18 L17 L19 K17 -   -   '
+			'K19 P18 R15 R17 R16 T20 T19 T18 T17 T15 '
 		),
-		Connector('j', 2,
-			'H16  A12  H15  B12  A13  B13  C13  D13  G18  G17  '
-			'-    -    H18  J18  J19  G11  H10  J11  H14  A15  '
-			'J13  L8   A14  B15  C15  E14  E15  E16  -    -    '
-			'F14  F15  F13  F12  G16  G15  G13  G12  J17  K16  '
+		Connector(
+			'j', 2,
+			'H16 A12 H15 B12 A13 B13 C13 D13 G18 G17 '
+			'-   -   H18 J18 J19 G11 H10 J11 H14 A15 '
+			'J13 L8  A14 B15 C15 E14 E15 E16 -   -   '
+			'F14 F15 F13 F12 G16 G15 G13 G12 J17 K16 '
 		),
 	]
 

--- a/torii_boards/altera/cyclone_v/de10_nano.py
+++ b/torii_boards/altera/cyclone_v/de10_nano.py
@@ -31,7 +31,6 @@ class DE10NanoPlatform(AlteraPlatform):
 		Resource(
 			'clk50', 2, Pins('E11', dir = 'i'), Clock(50e6), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		*LEDResources(
 			pins = 'W15 AA24 V16 V15 AF26 AE26 Y16 AA23',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
@@ -44,55 +43,58 @@ class DE10NanoPlatform(AlteraPlatform):
 			pins = 'Y24 W24 W21 W20',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Arduino header
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'AG13', tx = 'AF13',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# LTC2308 analogue-to-digital converter
-		SPIResource(0,
+		SPIResource(
+			0,
 			cs_n = 'U9', clk = 'V10', copi = 'AC4', cipo = 'AD4',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# ADV7513 HDMI transmitter
 		# Note this has a lot of input formats for tx_d, but this defaults to RGB24
-		Resource('adv7513', 0,
-			Subsignal('tx_d_r', Pins('AD12 AE12 W8   Y8   AD11 AD10 AE11 Y5',  dir = 'o')),
-			Subsignal('tx_d_g', Pins('AF10 Y4   AE9  AB4  AE7  AF6  AF8  AF5', dir = 'o')),
-			Subsignal('tx_d_b', Pins('AE4  AH2  AH4  AH5  AH6  AG6  AF9  AE8', dir = 'o')),
-			Subsignal('tx_clk', Pins('AG5',  dir = 'o')),
-			Subsignal('tx_de',  Pins('AD19', dir = 'o')),
-			Subsignal('tx_hs',  Pins('T8',   dir = 'o')),
-			Subsignal('tx_vs',  Pins('V13',  dir = 'o')),
+		Resource(
+			'adv7513', 0,
+			Subsignal('tx_d_r', Pins('AD12 AE12 W8 Y8 AD11 AD10 AE11 Y5', dir = 'o')),
+			Subsignal('tx_d_g', Pins('AF10 Y4 AE9 AB4 AE7 AF6 AF8 AF5', dir = 'o')),
+			Subsignal('tx_d_b', Pins('AE4 AH2 AH4 AH5 AH6 AG6 AF9 AE8', dir = 'o')),
+			Subsignal('tx_clk', Pins('AG5', dir = 'o')),
+			Subsignal('tx_de', Pins('AD19', dir = 'o')),
+			Subsignal('tx_hs', Pins('T8', dir = 'o')),
+			Subsignal('tx_vs', Pins('V13', dir = 'o')),
 			Subsignal('tx_int', Pins('AF11', dir = 'i')),
-			Subsignal('i2s0',   Pins('T13',  dir = 'o')),
-			Subsignal('mclk',   Pins('U11',  dir = 'o')),
-			Subsignal('lrclk',  Pins('T11',  dir = 'o')),
-			Subsignal('sclk',   Pins('T12',  dir = 'o')),
-			Subsignal('scl',    Pins('U10',  dir = 'io')),
-			Subsignal('sda',    Pins('AA4',  dir = 'io')),
+			Subsignal('i2s0', Pins('T13', dir = 'o')),
+			Subsignal('mclk', Pins('U11', dir = 'o')),
+			Subsignal('lrclk', Pins('T11', dir = 'o')),
+			Subsignal('sclk', Pins('T12', dir = 'o')),
+			Subsignal('scl', Pins('U10', dir = 'io')),
+			Subsignal('sda', Pins('AA4', dir = 'io')),
 			Attrs(io_standard = '3.3-V LVTTL')
 		),
 	]
 	connectors  = [
 		# Located on the top of the board, above the chip.
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'V12  E8   W12  D11  D8   AH13 AF7  AH14 AF4  AH3  '
 			'-    -    AD5  AG14 AE23 AE6  AD23 AE24 D12  AD20 '
 			'C12  AD17 AC23 AC22 Y19  AB23 AA19 W11  -    -    '
 			'AA18 W14  Y18  Y17  AB25 AB26 Y11  AA26 AA13 AA11 '
 		),
 		# Located on the bottom of the board.
-		Connector('gpio', 1,
+		Connector(
+			'gpio', 1,
 			'Y15  AC24 AA15 AD26 AG28 AF28 AE25 AF27 AG26 AH27 '
 			'-    -    AG25 AH26 AH24 AF25 AG23 AF23 AG24 AH22 '
 			'AH21 AG21 AH23 AA20 AF22 AE22 AG20 AF21 -    -    '
 			'AG19 AH19 AG18 AH18 AF18 AF20 AG15 AE20 AE19 AE17 '
 		),
-		Connector('arduino', 0,
+		Connector(
+			'arduino', 0,
 			'AG13 AF13 AG10 AG9  U14  U13  AG8  AH8  '
 			'AF17 AE15 AF15 AG16 AH11 AH12 AH9  AG11 '
 			'AH7  -    -    -    -    -    -    -    '

--- a/torii_boards/altera/cyclone_v/de1_soc.py
+++ b/torii_boards/altera/cyclone_v/de1_soc.py
@@ -31,7 +31,6 @@ class DE1SoCPlatform(AlteraPlatform):
 		Resource(
 			'clk50', 3, Pins('K14', dir = 'i'),  Clock(50e6), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		*LEDResources(
 			pins = 'V16 W16 V17 V18 W17 W19 Y19 W20 W21 Y21',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
@@ -44,32 +43,38 @@ class DE1SoCPlatform(AlteraPlatform):
 			pins = 'AB12 AC12 AF9 AF10 AD11 AD12 AE11 AC9 AD10 AE12',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'AE26', b = 'AE27', c = 'AE28', d = 'AG27', e = 'AF28',
 			f = 'AG28', g = 'AH28', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(1,
+		Display7SegResource(
+			1,
 			a = 'AJ29', b = 'AH29', c = 'AH30', d = 'AG30', e = 'AF29',
 			f = 'AF30', g = 'AD27', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(2,
+		Display7SegResource(
+			2,
 			a = 'AB23', b = 'AE29', c = 'AD29', d = 'AC28', e = 'AD30',
 			f = 'AC29', g = 'AC30', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(3,
+		Display7SegResource(
+			3,
 			a = 'AD26', b = 'AC27', c = 'AD25', d = 'AC25', e = 'AB28',
 			f = 'AB25', g = 'AB22', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(4,
+		Display7SegResource(
+			4,
 			a = 'AA24', b = 'Y23', c = 'Y24', d = 'W22', e = 'W24',
 			f = 'V23', g = 'W25', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(5,
+		Display7SegResource(
+			5,
 			a = 'V25', b = 'AA28', c = 'Y27', d = 'AB27', e = 'AB26',
 			f = 'AA26', g = 'AA25', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
@@ -78,17 +83,18 @@ class DE1SoCPlatform(AlteraPlatform):
 
 	connectors  = [
 		# Located on the right hand side of the board
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'AC18 Y17  AD17 Y18  AK16 AK18 AK19 AJ19 AJ17 AJ16 '
-			' -    -   AH18 AH17 AG16 AE16 AF16 AG17 AA18 AA19 '
-			'AE17 AC20 AH19 AJ20 AH20 AK21 AD19 AD20  -    -   '
+			'-    -    AH18 AH17 AG16 AE16 AF16 AG17 AA18 AA19 '
+			'AE17 AC20 AH19 AJ20 AH20 AK21 AD19 AD20 -    -    '
 			'AE18 AE19 AF20 AF21 AF19 AG21 AF18 AG20 AG18 AJ21 '
 		),
-
-		Connector('gpio', 1,
+		Connector(
+			'gpio', 1,
 			'AB17 AA21 AB21 AC23 AD24 AE23 AE24 AF25 AF26 AG25 '
 			'-    -    AG26 AH24 AH27 AJ27 AK29 AK28 AK27 AJ26 '
-			'AK26 AH25 AJ25 AJ24 AK24 AG23 AK23 AH23  -    -   '
+			'AK26 AH25 AJ25 AJ24 AK24 AG23 AK23 AH23 -    -    '
 			'AK22 AJ22 AH22 AG22 AF24 AF23 AE22 AD21 AA20 AC22 '
 		),
 	]

--- a/torii_boards/altera/cyclone_v/mister.py
+++ b/torii_boards/altera/cyclone_v/mister.py
@@ -32,7 +32,6 @@ class MisterPlatform(AlteraPlatform):
 		Resource(
 			'clk50', 2, Pins('E11', dir = 'i'), Clock(50e6), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		*LEDResources(
 			pins = 'W15 AA24 V16 V15 AF26 AE26 Y16 AA23',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
@@ -45,48 +44,47 @@ class MisterPlatform(AlteraPlatform):
 			pins = 'Y24 W24 W21 W20',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Arduino header
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'AG13', tx = 'AF13',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# LTC2308 analogue-to-digital converter
-		SPIResource(0,
+		SPIResource(
+			0,
 			cs_n = 'U9', clk = 'V10', copi = 'AC4', cipo = 'AD4',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# ADV7513 HDMI transmitter
 		# Note this has a lot of input formats for tx_d, but this defaults to RGB24
-		Resource('adv7513', 0,
-			Subsignal('tx_d_r', Pins('AD12 AE12 W8   Y8   AD11 AD10 AE11 Y5',  dir = 'o')),
-			Subsignal('tx_d_g', Pins('AF10 Y4   AE9  AB4  AE7  AF6  AF8  AF5', dir = 'o')),
-			Subsignal('tx_d_b', Pins('AE4  AH2  AH4  AH5  AH6  AG6  AF9  AE8', dir = 'o')),
-			Subsignal('tx_clk', Pins('AG5',  dir = 'o')),
-			Subsignal('tx_de',  Pins('AD19', dir = 'o')),
-			Subsignal('tx_hs',  Pins('T8',   dir = 'o')),
-			Subsignal('tx_vs',  Pins('V13',  dir = 'o')),
+		Resource(
+			'adv7513', 0,
+			Subsignal('tx_d_r', Pins('AD12 AE12 W8 Y8 AD11 AD10 AE11 Y5',  dir = 'o')),
+			Subsignal('tx_d_g', Pins('AF10 Y4 AE9 AB4 AE7 AF6 AF8 AF5', dir = 'o')),
+			Subsignal('tx_d_b', Pins('AE4 AH2 AH4 AH5 AH6 AG6 AF9 AE8', dir = 'o')),
+			Subsignal('tx_clk', Pins('AG5', dir = 'o')),
+			Subsignal('tx_de', Pins('AD19', dir = 'o')),
+			Subsignal('tx_hs', Pins('T8', dir = 'o')),
+			Subsignal('tx_vs', Pins('V13', dir = 'o')),
 			Subsignal('tx_int', Pins('AF11', dir = 'i')),
-			Subsignal('i2s0',   Pins('T13',  dir = 'o')),
-			Subsignal('mclk',   Pins('U11',  dir = 'o')),
-			Subsignal('lrclk',  Pins('T11',  dir = 'o')),
-			Subsignal('sclk',   Pins('T12',  dir = 'o')),
-			Subsignal('scl',    Pins('U10',  dir = 'io')),
-			Subsignal('sda',    Pins('AA4',  dir = 'io')),
+			Subsignal('i2s0', Pins('T13', dir = 'o')),
+			Subsignal('mclk', Pins('U11', dir = 'o')),
+			Subsignal('lrclk', Pins('T11', dir = 'o')),
+			Subsignal('sclk', Pins('T12', dir = 'o')),
+			Subsignal('scl', Pins('U10', dir = 'io')),
+			Subsignal('sda', Pins('AA4', dir = 'io')),
 			Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# MiSTer SDRAM Board (required)
 		# https://github.com/MiSTer-devel/Hardware_MiSTer/blob/master/releases/sdram_xs_2.2.pdf
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = '20', cs_n = '33', we_n = '27', ras_n = '32', cas_n = '31',
 			ba = '34 35', a = '37 38 39 40 28 25 26 23 24 21 36 22 19',
 			dq = '1 2 3 4 5 6 7 8 18 17 16 15 14 13 9 10',
 			dqm = '', conn = ('gpio', 0), attrs = Attrs(io_standard = '3.3-V LVCMOS')
 		),
-
 		# MiSTer I/O Board (optional, but highly recommended)
 		# https://github.com/MiSTer-devel/Hardware_MiSTer/blob/master/releases/iobrd_6.0.pdf
 		Resource(
@@ -98,7 +96,6 @@ class MisterPlatform(AlteraPlatform):
 		Resource(
 			'user_led', 0, PinsN('5', dir = 'o', conn = ('gpio', 1)), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		Resource(
 			'reset_switch', 0, PinsN('17', dir = 'i', conn = ('gpio', 1)), Attrs(io_standard = '3.3-V LVTTL')
 		),
@@ -108,23 +105,22 @@ class MisterPlatform(AlteraPlatform):
 		Resource(
 			'user_switch', 0, PinsN('15', dir = 'i', conn = ('gpio', 1)), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		Resource('audio', 0,
+		Resource(
+			'audio', 0,
 			Subsignal('l', Pins('2', dir = 'o', conn = ('gpio', 1))),
 			Subsignal('r', Pins('7', dir = 'o', conn = ('gpio', 1))),
 			Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		Resource('toslink', 0, Pins('9', dir = 'o', conn = ('gpio', 1))),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = '13', cmd = '8',
 			dat0 = '16', dat1 = '18', dat2 = '4', dat3 = '6',
 			conn = ('gpio', 1), attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# The schematic is difficult to understand here...
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = '28 32 34 36 38 40',
 			g = '27 31 33 35 37 39',
 			b = '21 23 25 26 24 24',
@@ -136,20 +132,23 @@ class MisterPlatform(AlteraPlatform):
 
 	connectors  = [
 		# Located on the top of the board, above the chip.
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'V12  E8   W12  D11  D8   AH13 AF7  AH14 AF4  AH3  '
 			'-    -    AD5  AG14 AE23 AE6  AD23 AE24 D12  AD20 '
 			'C12  AD17 AC23 AC22 Y19  AB23 AA19 W11  -    -    '
 			'AA18 W14  Y18  Y17  AB25 AB26 Y11  AA26 AA13 AA11 '
 		),
 		# Located on the bottom of the board.
-		Connector('gpio', 1,
+		Connector(
+			'gpio', 1,
 			'Y15  AC24 AA15 AD26 AG28 AF28 AE25 AF27 AG26 AH27 '
 			'-    -    AG25 AH26 AH24 AF25 AG23 AF23 AG24 AH22 '
 			'AH21 AG21 AH23 AA20 AF22 AE22 AG20 AF21 -    -    '
 			'AG19 AH19 AG18 AH18 AF18 AF20 AG15 AE20 AE19 AE17 '
 		),
-		Connector('arduino', 0,
+		Connector(
+			'arduino', 0,
 			'AG13 AF13 AG10 AG9  U14  U13  AG8  AH8  '
 			'AF17 AE15 AF15 AG16 AH11 AH12 AH9  AG11 '
 			'AH7  -    -    -    -    -    -    -    '

--- a/torii_boards/altera/max10/arrow_deca.py
+++ b/torii_boards/altera/max10/arrow_deca.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
+
 from torii.build                  import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run              import BuildProducts
 from torii.platform.resources     import ButtonResources, LEDResources, SwitchResources
@@ -20,11 +22,10 @@ class ArrowDECAPlatform(AlteraPlatform):
 	description = 'Arrow Development Tools DECA Altera MAX10 Development Kit'
 
 	resources   = [
-		Resource('clk50', 0, Pins('M8',  dir = 'i'), Clock(50e6), Attrs(io_standard = '2.5 V')),
+		Resource('clk50', 0, Pins('M8', dir = 'i'), Clock(50e6), Attrs(io_standard = '2.5 V')),
 		Resource('clk50', 1, Pins('P11', dir = 'i'), Clock(50e6), Attrs(io_standard = '3.3 V')),
 		Resource('clk50', 2, Pins('N15', dir = 'i'), Clock(50e6), Attrs(io_standard = '1.5 V')),
-		Resource('clk10', 0, Pins('M9',  dir = 'i'), Clock(10e6), Attrs(io_standard = '2.5 V')),
-
+		Resource('clk10', 0, Pins('M9', dir = 'i'), Clock(10e6), Attrs(io_standard = '2.5 V')),
 		*LEDResources(
 			pins = 'C7 C8 A6 B7 C4 A5 B4 C5',
 			invert = True,
@@ -42,16 +43,18 @@ class ArrowDECAPlatform(AlteraPlatform):
 	]
 
 	connectors  = [
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'W18  Y18  Y19  AA17 AA20 AA19 AB21 AB20 AB19 Y16  V16  '
 			'AB18 V15  W17  AB17 AA16 AB16 W16  AB15 W15  Y14  AA15 '
 			'AB14 AA14 AB13 AA13 AB12 AA12 AB11 AA11 AB10 Y13  Y11  '
 			'W13  W12  W11  V12  V11  V13  V14  Y17  W14  U15  R13  '
 		),
-		Connector('gpio', 1,
-			'Y5   Y6   W6   W7   W8   V8   AB8   V7  R11  AB7  AB6  '
-			'AA7  AA6  Y7   V10  U7   W9   W5   R9   W4    P9  V17  '
-			'W3   -    -    -    -    -    -    -    -     -   -    '
+		Connector(
+			'gpio', 1,
+			'Y5  Y6  W6  W7  W8  V8  AB8 V7  R11 AB7 AB6 '
+			'AA7 AA6 Y7  V10 U7  W9  W5  R9  W4  P9  V17 '
+			'W3  -   -   -   -   -   -   -   -   -   -   '
 		),
 	]
 
@@ -73,9 +76,7 @@ class ArrowDECAPlatform(AlteraPlatform):
 		# file templates before modifying them to avoid modifying the original.
 		return {
 			**super().file_templates,
-			'{{name}}.qsf':
-				super().file_templates.get('{{name}}.qsf') +
-				r'''
+			'{{name}}.qsf': super().file_templates.get('{{name}}.qsf') + dedent(r'''
 				set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1A
 				set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1B
 				set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 2
@@ -90,7 +91,7 @@ class ArrowDECAPlatform(AlteraPlatform):
 				set_global_assignment -name AUTO_RESTART_CONFIGURATION OFF
 				set_global_assignment -name ENABLE_CONFIGURATION_PINS OFF
 				set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF
-				'''
+			''')
 		}
 
 

--- a/torii_boards/altera/max10/de10_lite.py
+++ b/torii_boards/altera/max10/de10_lite.py
@@ -31,7 +31,6 @@ class DE10LitePlatform(AlteraPlatform):
 		Resource(
 			'clk50', 1, Pins('N14', dir = 'i'), Clock(50e6), Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		*LEDResources(
 			pins = 'A8 A9 A10 B10 D13 C13 E14 D14 A11 B11',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
@@ -44,45 +43,51 @@ class DE10LitePlatform(AlteraPlatform):
 			pins = 'C10 C11 D12 C12 A12 B12 A13 A14 B14 F15',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'C14', b = 'E15', c = 'C15', d = 'C16', e = 'E16', f = 'D17', g = 'C17', dp = 'D15', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(1,
+		Display7SegResource(
+			1,
 			a = 'C18', b = 'D18', c = 'E18', d = 'B16', e = 'A17', f = 'A18', g = 'B17', dp = 'A16', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(2,
+		Display7SegResource(
+			2,
 			a = 'B20', b = 'A20', c = 'B19', d = 'A21', e = 'B21', f = 'C22', g = 'B22', dp = 'A19', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(3,
+		Display7SegResource(
+			3,
 			a = 'F21', b = 'E22', c = 'E21', d = 'C19', e = 'C20', f = 'D19', g = 'E17', dp = 'D22', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(4,
+		Display7SegResource(
+			4,
 			a = 'F18', b = 'E20', c = 'E19', d = 'J18', e = 'H19', f = 'F19', g = 'F20', dp = 'F17', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-		Display7SegResource(5,
+		Display7SegResource(
+			5,
 			a = 'J20', b = 'K20', c = 'L18', d = 'N18', e = 'M20', f = 'N19', g = 'N20', dp = 'L19', invert = True,
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
 		# Arduino header
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'V10', tx = 'W10',
 			attrs = Attrs(io_standard = '3.3-V LVTTL')
 		),
-
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = 'L14', cs_n = 'U20', we_n = 'V20', ras_n = 'U22', cas_n = 'U21',
 			ba = 'T21 T22', a = 'U17 W19 V18 U18 U19 T18 T19 R18 P18 P19 T20 P20 R20',
 			dq = 'Y21 Y20 AA22 AA21 Y22 W22 W20 V21 P21 J22 H21 H22 G22 G20 G19 F22',
 			dqm = 'V22 J21', attrs = Attrs(io_standard = '3.3-V LVCMOS')
 		),
-
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = 'AA1 V1 Y2 Y1',
 			g = 'W1 T2 R2 R1',
 			b = 'P1 T1 P4 N2',
@@ -92,11 +97,13 @@ class DE10LitePlatform(AlteraPlatform):
 	]
 
 	connectors  = [
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'V10  W10 V9 W9  V8 W8  V7 W7  W6 V5  W5 AA15 AA14 W13 W12 AB13 AB12 Y11 AB11 W11 AB10 '
 			'AA10 AA9 Y8 AA8 Y7 AA7 Y6 AA6 Y5 AA5 Y4 AB3  Y3   AB2 AA2 -    -    -   -    -   -    '
 		),
-		Connector('gpio', 5,
+		Connector(
+			'gpio', 5,
 			'AB5 AB6 AB7 AB8 AB9 Y10 AA11 AA12 AB17 AA17 AB19 AA19 Y19 AB20 AB21 AA20 F16'
 		),
 	]

--- a/torii_boards/gowin/gw1n/tang_nano.py
+++ b/torii_boards/gowin/gw1n/tang_nano.py
@@ -25,37 +25,32 @@ class TangNanoPlatform(GowinPlatform):
 		Resource(
 			'clk24', 0, Pins('35', dir = 'i'), Clock(24_000_000), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		RGBLEDResource(0, r = '18', g = '16', b = '17', attrs = Attrs(IO_TYPE = 'LVCMOS33')),
-
 		*ButtonResources(pins = '15 14', invert = True, attrs = Attrs(IO_TYPE = 'LVCMOS33')),
-
 		UARTResource(0, tx = '9', rx = '8', attrs = Attrs(IO_TYPE = 'LVCMOS33', PULL_MODE = 'UP')),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '19', clk = '20', copi = '22', cipo = '23', wp_n = '24', hold_n = '25',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('lcd', 0,
-			Subsignal('clk', Pins('11',                dir = 'o')),
-			Subsignal('hs',  Pins('10',                dir = 'o')),
-			Subsignal('vs',  Pins('46',                dir = 'o')),
-			Subsignal('de',  Pins('5',                 dir = 'o')),
-			Subsignal('r',   Pins('27 28 29 30 31',    dir = 'o')),
-			Subsignal('g',   Pins('32 33 34 38 39 40', dir = 'o')),
-			Subsignal('b',   Pins('41 42 43 44 45',    dir = 'o')),
-			Attrs(IO_TYPE = 'LVCMOS33')),
-
+		Resource(
+			'lcd', 0,
+			Subsignal('clk', Pins('11', dir = 'o')),
+			Subsignal('hs', Pins('10', dir = 'o')),
+			Subsignal('vs', Pins('46', dir = 'o')),
+			Subsignal('de', Pins('5', dir = 'o')),
+			Subsignal('r', Pins('27 28 29 30 31', dir = 'o')),
+			Subsignal('g', Pins('32 33 34 38 39 40', dir = 'o')),
+			Subsignal('b', Pins('41 42 43 44 45', dir = 'o')),
+			Attrs(IO_TYPE = 'LVCMOS33')
+		),
 		Resource('lcd_backlight', 0, Pins('47', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33')),
 	]
 
 	def toolchain_prepare(self, fragment, name, **kwargs):
 		overrides = {
-			'add_options':
-				'set_option -use_mspi_as_gpio 1 -use_sspi_as_gpio 1',
-			'gowin_pack_opts':
-				'--sspi_as_gpio --mspi_as_gpio'
+			'add_options': 'set_option -use_mspi_as_gpio 1 -use_sspi_as_gpio 1',
+			'gowin_pack_opts': '--sspi_as_gpio --mspi_as_gpio'
 		}
 		return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 

--- a/torii_boards/lattice/ecp5/colorlight_5a75b_r7_0.py
+++ b/torii_boards/lattice/ecp5/colorlight_5a75b_r7_0.py
@@ -21,83 +21,83 @@ class Colorlight_5A75B_R70Platform(ECP5Platform):
 
 	resources   = [
 		Resource('clk25', 0, Pins('P6', dir = 'i'), Clock(25e6), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		*LEDResources(
 			pins = 'P11', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4')
 		),
-
 		*ButtonResources(
 			pins = 'M13', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			tx = 'P11', # led (J19 DATA_LED-)
 			rx = 'M13', # btn (J19 KEY+)
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# SPIFlash (W25Q32JV)   1x/2x/4x speed
-		Resource('spi_flash', 0,
-			Subsignal('cs',   PinsN('N8', dir = 'o')),
+		Resource(
+			'spi_flash', 0,
+			Subsignal('cs', PinsN('N8', dir = 'o')),
 			# Subsignal('clk', Pins(', dir = 'i')),             # driven through USRMCLK
 			Subsignal('cipo', Pins('T8', dir = 'i')),           # Chip: DI/IO0
-			Subsignal('copi', Pins('T7', dir = 'o')),           #       DO/IO1
+			Subsignal('copi', Pins('T7', dir = 'o')),           # DO/IO1
 			# Subsignal('wp', PinsN('unknown', dir = 'o')),     #          IO2 Todo
 			# Subsignal('hold', PinsN('unknown', dir = 'o')),   #          IO3 Todo
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# 2x ESMT M12L16161A-5T 1M x 16bit 200MHz SDRAMs (organized as 1M x 32bit)
 		# 2x WinBond W9816G6JH-6 1M x 16bit 166MHz SDRAMs (organized as 1M x 32bit) are lso reported
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = 'C6', we_n = 'C7', cas_n = 'E7', ras_n = 'D7',
 			ba = 'A7', a = 'A9 E10 B12 D13 C12 D11 D10 E9 D9 B7 C8',
-			dq = 'B13 C11 C10 A11 C9 E8  B6  B9  A6  B5  A5  B4  B3 C3  A2  B2 '
-				'E2  D3  A4  E4  D4 C4  E5  D5  E6  D6  D8  A8  B8 B10 B11 E11',
+			dq = '''
+				B13 C11 C10 A11 C9 E8  B6  B9  A6  B5  A5  B4  B3 C3  A2  B2
+				E2  D3  A4  E4  D4 C4  E5  D5  E6  D6  D8  A8  B8 B10 B11 E11
+			''',
 			attrs = Attrs(PULLMODE = 'NONE', DRIVE = '4', SLEWRATE = 'FAST', IO_TYPE = 'LVCMOS33')
 		),
-
 		# Broadcom B50612D Gigabit Ethernet Transceiver
-		Resource('eth_rgmii', 0,
-			Subsignal('rst',     PinsN('P5', dir = 'o')),
-			Subsignal('mdc',     Pins('P3', dir = 'o')),
-			Subsignal('mdio',    Pins('T2', dir = 'io')),
-			Subsignal('tx_clk',  Pins('M2', dir = 'o')),
-			Subsignal('tx_ctl',  Pins('M3', dir = 'o')),
+		Resource(
+			'eth_rgmii', 0,
+			Subsignal('rst', PinsN('P5', dir = 'o')),
+			Subsignal('mdc', Pins('P3', dir = 'o')),
+			Subsignal('mdio', Pins('T2', dir = 'io')),
+			Subsignal('tx_clk', Pins('M2', dir = 'o')),
+			Subsignal('tx_ctl', Pins('M3', dir = 'o')),
 			Subsignal('tx_data', Pins('L1 L3 P2 L4', dir = 'o')),
-			Subsignal('rx_clk',  Pins('M1', dir = 'i')),
-			Subsignal('rx_ctl',  Pins('N6', dir = 'i')),
+			Subsignal('rx_clk', Pins('M1', dir = 'i')),
+			Subsignal('rx_ctl', Pins('N6', dir = 'i')),
 			Subsignal('rx_data', Pins('N1 M5 N5 M6', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# Broadcom B50612D Gigabit Ethernet Transceiver
-		Resource('eth_rgmii', 1,
-			Subsignal('rst',     PinsN('P5', dir = 'o')),
-			Subsignal('mdc',     Pins('P3', dir = 'o')),
-			Subsignal('mdio',    Pins('T2', dir = 'io')),
-			Subsignal('tx_clk',  Pins('M12', dir = 'o')),
-			Subsignal('tx_ctl',  Pins('R15', dir = 'o')),
+		Resource(
+			'eth_rgmii', 1,
+			Subsignal('rst', PinsN('P5', dir = 'o')),
+			Subsignal('mdc', Pins('P3', dir = 'o')),
+			Subsignal('mdio', Pins('T2', dir = 'io')),
+			Subsignal('tx_clk', Pins('M12', dir = 'o')),
+			Subsignal('tx_ctl', Pins('R15', dir = 'o')),
 			Subsignal('tx_data', Pins('T14 R12 R13 R14', dir = 'o')),
-			Subsignal('rx_clk',  Pins('M16', dir = 'i')),
-			Subsignal('rx_ctl',  Pins('L15', dir = 'i')),
+			Subsignal('rx_clk', Pins('M16', dir = 'i')),
+			Subsignal('rx_ctl', Pins('L15', dir = 'i')),
 			Subsignal('rx_data', Pins('P13 N13 P14 M15', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
 
 	]
 	connectors = [
-		Connector('j',  1, 'F3  F1  G3  - G2  H3  H5  F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  2, 'J4  K3  G1  - K4  C2  E3  F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  3, 'H4  K5  P1  - R1  L5  F2  F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  4, 'P4  R2  M8  - M9  T6  R6  F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  5, 'M11 N11 P12 - K15 N12 L16 F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  6, 'K16 J15 J16 - J12 H15 G16 F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  7, 'H13 J13 H12 - G14 H14 G15 F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j',  8, 'A15 F16 A14 - E13 B14 A13 F15 L2 K1 J5 K2 B16 J14 F12 -'),
-		Connector('j', 19, ' -  M13  -  - P11'),
+		Connector('j', 1, 'F3 F1 G3 - G2 H3 H5 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 2, 'J4 K3 G1 - K4 C2 E3 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 3, 'H4 K5 P1 - R1 L5 F2 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 4, 'P4 R2 M8 - M9 T6 R6 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 5, 'M11 N11 P12 - K15 N12 L16 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 6, 'K16 J15 J16 - J12 H15 G16 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 7, 'H13 J13 H12 - G14 H14 G15 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 8, 'A15 F16 A14 - E13 B14 A13 F15 L2 K1 J5 K2 B16 J14 F12 -'),
+		Connector('j', 19, '-  M13 - - P11'),
 	]
 
 	@property

--- a/torii_boards/lattice/ecp5/ecp5_5g_evn.py
+++ b/torii_boards/lattice/ecp5/ecp5_5g_evn.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from typing      import Literal
+from textwrap                           import dedent
+from typing                             import Literal
 
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildProducts
@@ -60,12 +61,10 @@ class ECP55GEVNPlatform(ECP5Platform):
 		Resource(
 			'clk12', 0, Pins('A10', dir = 'i'), Clock(12e6), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# By default this CLK is not populated, see User Manual Section 4.
 		Resource(
 			'extclk', 0, Pins('B11', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		*LEDResources(
 			pins = 'A13 A12 B19 A18 B18 C17 A17 B17', invert = True,
 			attrs = Attrs(IO_TYPE = bank1_iostandard)
@@ -81,72 +80,77 @@ class ECP55GEVNPlatform(ECP5Platform):
 			pins = {4: 'E15', 5: 'D16', 6: 'B16', 7: 'C16', 8: 'A16'}, invert = True,
 			attrs = Attrs(IO_TYPE = bank1_iostandard)
 		),
-
 		# In order to use the UART as a UART you need to swap two resistor jumpers,
 		# and potentially reconfigure the onboard FTDI chip, see section 6.2 in the
 		# User Manual for hardware instructions, and
 		# https://github.com/trabucayre/fixFT2232_ecp5evn to reconfigure the FTDI.
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'P2', tx = 'P3',
 			attrs = Attrs(IO_TYPE = bank6_iostandard, PULLMODE = 'UP')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'R2', clk = 'U3', cipo = 'V2', copi = 'W2', wp_n = 'Y2', hold_n = 'W1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('serdes', 0,
+		Resource(
+			'serdes', 0,
 			Subsignal('tx', DiffPairs('W4', 'W5', dir = 'o')),
 			Subsignal('rx', DiffPairs('Y5', 'Y6', dir = 'i')),
 		),
-		Resource('serdes', 1,
+		Resource(
+			'serdes', 1,
 			Subsignal('tx', DiffPairs('W8', 'W9', dir = 'o')),
 			Subsignal('rx', DiffPairs('Y7', 'Y8', dir = 'i')),
 		),
-		Resource('serdes', 2,
+		Resource(
+			'serdes', 2,
 			Subsignal('tx', DiffPairs('W13', 'W14', dir = 'o')),
 			Subsignal('rx', DiffPairs('Y14', 'Y15', dir = 'i')),
 		),
-		Resource('serdes', 3,
+		Resource(
+			'serdes', 3,
 			Subsignal('tx', DiffPairs('W17', 'W18', dir = 'o')),
 			Subsignal('rx', DiffPairs('Y16', 'Y17', dir = 'i')),
 		),
-
 		Resource('serdes_clk', 0, DiffPairs('Y11', 'Y12', dir = 'i')),
 		Resource('serdes_clk', 1, DiffPairs('Y19', 'W20', dir = 'i')), # 200 MHz
-
 		# TODO: add other resources
 	]
 	connectors  = [
 		# Expansion connectors
-		Connector('J', 39,
-			'- - - D15 B15 C15 B13 B20 D11 E11 B12 C12 D12 E12 C13 D13  '
-			'E13 A14 A9 B10 - - - - - - - - E7 - A11 - A19 - - - - - - -'
+		Connector(
+			'J', 39,
+			'-   -   -   D15 B15 C15 B13 B20 D11 E11 B12 C12 D12 E12 C13 D13 E13 A14 A9  B10 '
+			'-   -   -   -   -   -   -   -   E7  -   A11 -   A19 -   -   -   -   -   -   -   '
 		),
-		Connector('J', 40,
-			'K2 - A15 F1 H2 G1 J4 J5 J3 K3 L4 L5 M4 N5 N4 P5 N3 M3 - - K5'
-			'- M5 - L3 - N2 M1 L2 - L1 N1 C14 - P1 E14 D14 - K4 -  - - - '
+		Connector(
+			'J', 40,
+			'K2  -   A15 F1  H2  G1  J4  J5  J3  K3  L4  L5  M4  N5  N4  P5  N3  M3  -   - '
+			'K5  -   M5  -   L3  -   N2  M1  L2  -   L1  N1  C14 -   P1  E14 D14 -   K4  - '
+			'-   -   - '
 		),
-
 		# Arduino
 		Connector('J', 6, 'K16 J16 H17 J17 H18 H16 - G18 G16 F17'),
 		Connector('J', 3, 'F19 F20 E20 E19 D19 D20 C20 K17'),
 		Connector('J', 7, 'C18 - D17 - - - - -'),
 		Connector('J', 4, 'F18 E17 E18 D18 F16 E16'),
 		# Raspberry Pi
-		Connector('JP', 8,
-			'- - T17 - U16 - U17 P18 - N20 N19 T16 M18 - N17 P17 - M17 U20 - '
-			'T19 N18 R20 U19 - R18 L18 L17 U18 - T18 T20 P20 - R17 P19 N16 P16 - R16'
+		Connector(
+			'JP', 8,
+			'-   -   T17 -   U16 -   U17 P18 -   N20 N19 T16 M18 -   N17 P17 -   M17 U20 -  '
+			'T19 N18 R20 U19 -   R18 L18 L17 U18 -   T18 T20 P20 -   R17 P19 N16 P16 -   R16'
 		),
-		# GPIO
-		Connector('J', 5, '- - H20 G19 - - K18 J18 - - K19 J19 - - K20 J20 - - G20 - - -'), # Contains 4 differential pairs
+		# GPIO, J5 Contains 4 differential pairs
+		Connector('J', 5, '- - H20 G19 - - K18 J18 - - K19 J19 - - K20 J20 - - G20 - - -'),
 		Connector('J', 8, '- - L19 M19 L20 M20 L16 -'),
-		Connector('J', 32,
-			'- - - - A5 A4 - - C5 B5 - - B4 C4 - - B3 A3 - - D5 E4 - - D3 C3 - - E3'
-			'F4 - - F5 E5 - - B1 A2 - -'
+		Connector(
+			'J', 32,
+			'- - - - A5 A4 - - C5 B5 - - B4 C4 - - B3 A3 - - D5 E4 - - D3 C3 - - E3 F4 - - F5 E5 - - B1 A2 - -'
 		), # Contains 9 differential pairs
-		Connector('J', 33,
+		Connector(
+			'J', 33,
 			'- - - - C2 B2 - - D1 C1 - - E1 D2 - - G5 H4 - - H3 H5 - - F3 G3 - - E2 F2 - -'
 		), # Contains 7 differential pairs
 		# Mic
@@ -155,17 +159,15 @@ class ECP55GEVNPlatform(ECP5Platform):
 		Connector('J', 31, 'C6 C7 E8 D8 - - C8 B8 A7 A8 - -'),
 		# JTAG
 		Connector('J', 1, '- V4 R5 - - U5 - T5'),
-		# Parallel configuration
-		Connector(
-			'J', 38, 'W3 R2 T3 Y3 R1 V3 T1 V2 U1 W2 V1 T2 W1 U2 Y2 R2 U3 R3 - -'
-		), # Connect pin 2 / R2 with jumper when needed
+		# Parallel configuration, Connect pin 2 / R2 with jumper when needed
+		Connector('J', 38, 'W3 R2 T3 Y3 R1 V3 T1 V2 U1 W2 V1 T2 W1 U2 Y2 R2 U3 R3 - -'),
 	]
 
 	@property
 	def file_templates(self) -> dict[str, str]:
 		return {
 			**super().file_templates,
-			'{{name}}-openocd.cfg': r'''
+			'{{name}}-openocd.cfg': dedent(r'''
 			interface ftdi
 			ftdi_device_desc 'Lattice ECP5 Evaluation Board'
 			ftdi_vid_pid 0x0403 0x6010
@@ -175,7 +177,7 @@ class ECP55GEVNPlatform(ECP5Platform):
 			adapter_khz 25000
 
 			jtag newtap ecp5 tap -irlen 8 -expected-id 0x81113043
-			'''
+			''')
 		}
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ecp5/ecpix5.py
+++ b/torii_boards/lattice/ecp5/ecpix5.py
@@ -21,95 +21,102 @@ class _ECPIX5Platform(ECP5Platform):
 		Resource(
 			'clk100', 0, Pins('K23', dir = 'i'), Clock(100e6), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'T23', g = 'R21', b = 'T22', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-		RGBLEDResource(1,
+		RGBLEDResource(
+			1,
 			r = 'U21', g = 'W21', b = 'T24', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-		RGBLEDResource(2,
+		RGBLEDResource(
+			2,
 			r = 'K21', g = 'K24', b = 'M21', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-		RGBLEDResource(3,
+		RGBLEDResource(
+			3,
 			r = 'P21', g = 'R23', b = 'P22', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'R26', tx = 'R24',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'AA2', clk = 'AE3', cipo = 'AE2', copi = 'AD2', wp_n = 'AF2', hold_n = 'AE1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('eth_rgmii', 0,
-			Subsignal('rst',     PinsN('C13', dir = 'o')),
-			Subsignal('mdio',    Pins('A13', dir = 'io')),
-			Subsignal('mdc',     Pins('C11', dir = 'o')),
-			Subsignal('tx_clk',  Pins('A12', dir = 'o')),
+		Resource(
+			'eth_rgmii', 0,
+			Subsignal('rst', PinsN('C13', dir = 'o')),
+			Subsignal('mdio', Pins('A13', dir = 'io')),
+			Subsignal('mdc', Pins('C11', dir = 'o')),
+			Subsignal('tx_clk', Pins('A12', dir = 'o')),
 			Subsignal('tx_ctrl', Pins('C9', dir = 'o')),
 			Subsignal('tx_data', Pins('D8 C8 B8 A8', dir = 'o')),
-			Subsignal('rx_clk',  Pins('E11', dir = 'i')),
+			Subsignal('rx_clk', Pins('E11', dir = 'i')),
 			Subsignal('rx_ctrl', Pins('A11', dir = 'i')),
 			Subsignal('rx_data', Pins('B11 A10 B10 A9', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		Resource('eth_int', 0, PinsN('B13', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33')),
-
-		Resource('ddr3', 0,
-			Subsignal('clk',    DiffPairs('H3', 'J3', dir = 'o'), Attrs(IO_TYPE = 'SSTL15D_I')),
+		Resource(
+			'ddr3', 0,
+			Subsignal('clk', DiffPairs('H3', 'J3', dir = 'o'), Attrs(IO_TYPE = 'SSTL15D_I')),
 			Subsignal('clk_en', Pins('P1', dir = 'o')),
-			Subsignal('we',     PinsN('R3', dir = 'o')),
-			Subsignal('ras',    PinsN('T3', dir = 'o')),
-			Subsignal('cas',    PinsN('P2', dir = 'o')),
-			Subsignal('a',      Pins('T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1 H1', dir = 'o')),
-			Subsignal('ba',     Pins('U6 N3 N4', dir = 'o')),
-			Subsignal('dqs',    DiffPairs('V4 V1', 'U5 U2', dir = 'io'),
-								Attrs(IO_TYPE = 'SSTL15D_I', TERMINATION = 'OFF', DIFFRESISTOR = '100')),
-			Subsignal('dq',     Pins('T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2', dir = 'io'),
-								Attrs(TERMINATION = '75')),
-			Subsignal('dm',     Pins('U4 U1', dir = 'o')),
-			Subsignal('odt',    Pins('P3', dir = 'o')),
+			Subsignal('we', PinsN('R3', dir = 'o')),
+			Subsignal('ras', PinsN('T3', dir = 'o')),
+			Subsignal('cas', PinsN('P2', dir = 'o')),
+			Subsignal('a', Pins('T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1 H1', dir = 'o')),
+			Subsignal('ba', Pins('U6 N3 N4', dir = 'o')),
+			Subsignal(
+				'dqs', DiffPairs('V4 V1', 'U5 U2', dir = 'io'),
+				Attrs(IO_TYPE = 'SSTL15D_I', TERMINATION = 'OFF', DIFFRESISTOR = '100')
+			),
+			Subsignal(
+				'dq', Pins('T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2', dir = 'io'),
+				Attrs(TERMINATION = '75')
+			),
+			Subsignal('dm', Pins('U4 U1', dir = 'o')),
+			Subsignal('odt', Pins('P3', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL15_I', SLEWRATE = 'FAST')
 		),
-
-		Resource('sata', 0,
+		Resource(
+			'sata', 0,
 			Subsignal('tx', DiffPairs('AD16', 'AD17', dir = 'o')),
 			Subsignal('rx', DiffPairs('AF15', 'AF16', dir = 'i')),
 			Attrs(IO_TYPE = 'LVDS')
 		),
-
-		ULPIResource('ulpi', 0,
+		ULPIResource(
+			'ulpi', 0,
 			data = 'M26 L25 L26 K25 K26 J23 P25 H25',
 			clk = 'H24', clk_dir = 'i', dir = 'F22', nxt = 'F23',
 			stp = 'H23', rst = 'E23', rst_invert = False,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'SLOW')
 		),
-
-		Resource('usbc_cfg', 0,
+		Resource(
+			'usbc_cfg', 0,
 			Subsignal('scl', Pins('D24', dir = 'io')),
 			Subsignal('sda', Pins('C24', dir = 'io')),
 			Subsignal('dir', Pins('B23', dir = 'i')),
-			Subsignal('id',  Pins('D23', dir = 'i')),
+			Subsignal('id', Pins('D23', dir = 'i')),
 			Subsignal('int', PinsN('B24', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('usbc_mux', 0,
-			Subsignal('en',    Pins('C23', dir = 'oe')),
+		Resource(
+			'usbc_mux', 0,
+			Subsignal('en', Pins('C23', dir = 'oe')),
 			Subsignal('amsel', Pins('B26', dir = 'oe')),
-			Subsignal('pol',   Pins('D26', dir = 'o')),
-			Subsignal('lna',   DiffPairs( 'AF9', 'AF10', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS18D')),
-			Subsignal('lnb',   DiffPairs('AD10', 'AD11', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS18D')),
-			Subsignal('lnc',   DiffPairs( 'AD7',  'AD8', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS18D')),
-			Subsignal('lnd',   DiffPairs( 'AF6',  'AF7', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS18D')),
+			Subsignal('pol', Pins('D26', dir = 'o')),
+			Subsignal('lna', DiffPairs('AF9', 'AF10', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS18D')),
+			Subsignal('lnb', DiffPairs('AD10', 'AD11', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS18D')),
+			Subsignal('lnc', DiffPairs('AD7', 'AD8', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS18D')),
+			Subsignal('lnd', DiffPairs('AF6', 'AF7', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS18D')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
 	]
@@ -118,7 +125,7 @@ class _ECPIX5Platform(ECP5Platform):
 		Connector('pmod', 0, 'T25 U25 U24 V24 - - T26 U26 V26 W26 - -'),
 		Connector('pmod', 1, 'U23 V23 U22 V21 - - W25 W24 W23 W22 - -'),
 		Connector('pmod', 2, 'J24 H22 E21 D18 - - K22 J21 H21 D22 - -'),
-		Connector('pmod', 3, ' E4  F4  E6  H4 - -  F3  D4  D5  F5 - -'),
+		Connector('pmod', 3, 'E4 F4 E6 H4 - - F3 D4 D5 F5 - -'),
 		Connector('pmod', 4, 'E26 D25 F26 F25 - - C26 C25 A25 A24 - -'),
 		Connector('pmod', 5, 'D19 C21 B21 C22 - - D21 A21 A22 A23 - -'),
 		Connector('pmod', 6, 'C16 B17 C18 B19 - - A17 A18 A19 C19 - -'),
@@ -143,26 +150,27 @@ class ECPIX545Platform(_ECPIX5Platform):
 
 	resources   = [
 		*_ECPIX5Platform.resources,
-
 		# The IT6613E HDMI transmitter has access to 8 bits per color channel.
-		Resource('it6613e', 0,
-			Subsignal('rst',   PinsN('N6', dir = 'o')),
-			Subsignal('scl',   Pins('C17', dir = 'io')),
-			Subsignal('sda',   Pins('E17', dir = 'io')),
-			Subsignal('pclk',  Pins('C1', dir = 'o')),
+		Resource(
+			'it6613e', 0,
+			Subsignal('rst', PinsN('N6', dir = 'o')),
+			Subsignal('scl', Pins('C17', dir = 'io')),
+			Subsignal('sda', Pins('E17', dir = 'io')),
+			Subsignal('pclk', Pins('C1', dir = 'o')),
 			Subsignal('vsync', Pins('A4', dir = 'o')),
 			Subsignal('hsync', Pins('B4', dir = 'o')),
-			Subsignal('de',    Pins('A3', dir = 'o')),
-			Subsignal('d',
-				Subsignal('b', Pins(' B3  C3  D3  B1  C2  D2 D1 E3', dir = 'o')),
-				Subsignal('g', Pins(' E1  F2  F1 D17 D16 E16 J6 H6', dir = 'o')),
-				Subsignal('r', Pins('E10 D11 D10 C10  D9  E8 H5 J4', dir = 'o')),
+			Subsignal('de', Pins('A3', dir = 'o')),
+			Subsignal(
+				'd',
+				Subsignal('b', Pins('B3 C3 D3 B1 C2 D2 D1 E3', dir = 'o')),
+				Subsignal('g', Pins('E1 F2 F1 D17 D16 E16 J6 H6', dir = 'o')),
+				Subsignal('r', Pins('E10 D11 D10 C10 D9 E8 H5 J4', dir = 'o')),
 			),
-			Subsignal('mclk',  Pins('E19', dir = 'o')),
-			Subsignal('sck',   Pins('D6', dir = 'o')),
-			Subsignal('ws',    Pins('C6', dir = 'o')),
-			Subsignal('i2s',   Pins('A6 B6 A5 C5', dir = 'o')),
-			Subsignal('int',   PinsN('C4', dir = 'i')),
+			Subsignal('mclk', Pins('E19', dir = 'o')),
+			Subsignal('sck', Pins('D6', dir = 'o')),
+			Subsignal('ws', Pins('C6', dir = 'o')),
+			Subsignal('i2s', Pins('A6 B6 A5 C5', dir = 'o')),
+			Subsignal('int', PinsN('C4', dir = 'i')),
 			Attrs(IO_TYPE = 'LVTTL33')
 		),
 	]
@@ -176,27 +184,28 @@ class ECPIX585Platform(_ECPIX5Platform):
 
 	resources   = [
 		*_ECPIX5Platform.resources,
-
 		# The IT6613E HDMI transmitter has access to 12 bits per color channel. The LFE5UM5G-85F
 		# has an additional I/O bank which is used to provide the lower 4 bits of each channel.
-		Resource('it6613e', 0,
-			Subsignal('rst',   PinsN('N6', dir = 'o')),
-			Subsignal('scl',   Pins('C17', dir = 'io')),
-			Subsignal('sda',   Pins('E17', dir = 'io')),
-			Subsignal('pclk',  Pins('C1', dir = 'o')),
+		Resource(
+			'it6613e', 0,
+			Subsignal('rst', PinsN('N6', dir = 'o')),
+			Subsignal('scl', Pins('C17', dir = 'io')),
+			Subsignal('sda', Pins('E17', dir = 'io')),
+			Subsignal('pclk', Pins('C1', dir = 'o')),
 			Subsignal('vsync', Pins('A4', dir = 'o')),
 			Subsignal('hsync', Pins('B4', dir = 'o')),
-			Subsignal('de',    Pins('A3', dir = 'o')),
-			Subsignal('d',
-				Subsignal('b', Pins('AD25 AC26 AB24 AB25  B3  C3  D3  B1  C2  D2 D1 E3', dir = 'o')),
-				Subsignal('g', Pins('AA23 AA22 AA24 AA25  E1  F2  F1 D17 D16 E16 J6 H6', dir = 'o')),
-				Subsignal('r', Pins('AD26 AE25 AF25 AE26 E10 D11 D10 C10  D9  E8 H5 J4', dir = 'o')),
+			Subsignal('de', Pins('A3', dir = 'o')),
+			Subsignal(
+				'd',
+				Subsignal('b', Pins('AD25 AC26 AB24 AB25 B3 C3 D3 B1 C2 D2 D1 E3', dir = 'o')),
+				Subsignal('g', Pins('AA23 AA22 AA24 AA25 E1 F2 F1 D17 D16 E16 J6 H6', dir = 'o')),
+				Subsignal('r', Pins('AD26 AE25 AF25 AE26 E10 D11 D10 C10 D9 E8  H5 J4', dir = 'o')),
 			),
-			Subsignal('mclk',  Pins('E19', dir = 'o')),
-			Subsignal('sck',   Pins('D6', dir = 'o')),
-			Subsignal('ws',    Pins('C6', dir = 'o')),
-			Subsignal('i2s',   Pins('A6 B6 A5 C5', dir = 'o')),
-			Subsignal('int',   PinsN('C4', dir = 'i')),
+			Subsignal('mclk', Pins('E19', dir = 'o')),
+			Subsignal('sck', Pins('D6', dir = 'o')),
+			Subsignal('ws', Pins('C6', dir = 'o')),
+			Subsignal('i2s', Pins('A6 B6 A5 C5', dir = 'o')),
+			Subsignal('int', PinsN('C4', dir = 'i')),
 			Attrs(IO_TYPE = 'LVTTL33')
 		),
 	]

--- a/torii_boards/lattice/ecp5/logicbone.py
+++ b/torii_boards/lattice/ecp5/logicbone.py
@@ -27,88 +27,90 @@ class LogicbonePlatform(ECP5Platform):
 		Resource(
 			'refclk', 0, Pins('M19', dir = 'i'), Clock(25e6), Attrs(IO_TYPE = 'LVCMOS18')
 		),
-
 		# SerDes connections.
-		Resource('serdes', 0,
+		Resource(
+			'serdes', 0,
 			Subsignal('rx', DiffPairs('Y5', 'Y6')),
 			Subsignal('tx', DiffPairs('W4', 'W5')),
 		),
-		Resource('serdes', 1,
+		Resource(
+			'serdes', 1,
 			Subsignal('rx', DiffPairs('Y8', 'Y7')),
 			Subsignal('tx', DiffPairs('W8', 'W9')),
 		),
-
 		# VBUS Detection is on the USB-C PD controller for both ports.
-		DirectUSBResource('usb', 0,
+		DirectUSBResource(
+			'usb', 0,
 			d_p = 'B12', d_n = 'C12', pullup = 'C16',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-		DirectUSBResource('usb', 1,
+		DirectUSBResource(
+			'usb', 1,
 			d_p = 'R1',  d_n = 'T1',  pullup = 'T2',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		*LEDResources(pins = 'D16 C15 C13 B13', attrs = Attrs(IO_TYPE = 'LVCMOS33'), invert = True),
-
 		*ButtonResources(pins = 'U2', attrs = Attrs(IO_TYPE = 'LVCMOS33'), invert = True),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'R2', clk = 'U3', cipo = 'V2', copi = 'W2', wp_n = 'Y2', hold_n = 'W1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'E11', cmd = 'D15', cd = 'D14',
 			dat0 = 'D13', dat1 = 'E13', dat2 = 'E15', dat3 = 'E13',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		Resource(
 			'eth_clk125', 0, Pins('A19', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-		Resource('eth_rgmii', 0,
+		Resource(
+			'eth_rgmii', 0,
 			# Stolen for sys_reset usage on prototypes.
 			# Subsignal('rst',     PinsN('U17', dir = 'o')),
-			Subsignal('int',     Pins('B20', dir = 'i')),
-			Subsignal('mdc',     Pins('D12', dir = 'o')),
-			Subsignal('mdio',    Pins('B19', dir = 'io')),
-			Subsignal('tx_clk',  Pins('A15', dir = 'o')),
-			Subsignal('tx_ctl',  Pins('B15', dir = 'o')),
+			Subsignal('int', Pins('B20', dir = 'i')),
+			Subsignal('mdc', Pins('D12', dir = 'o')),
+			Subsignal('mdio', Pins('B19', dir = 'io')),
+			Subsignal('tx_clk', Pins('A15', dir = 'o')),
+			Subsignal('tx_ctl', Pins('B15', dir = 'o')),
 			Subsignal('tx_data', Pins('A12 A13 C14 A14', dir = 'o')),
-			Subsignal('rx_clk',  Pins('B18', dir = 'i')),
-			Subsignal('rx_ctl',  Pins('A18', dir = 'i')),
+			Subsignal('rx_clk', Pins('B18', dir = 'i')),
+			Subsignal('rx_ctl', Pins('A18', dir = 'i')),
 			Subsignal('rx_data', Pins('B17 A17 B16 A16', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',     PinsN('P1', dir = 'o')),
-			Subsignal('clk',     DiffPairs('M4', 'N5', dir = 'o'), Attrs(IO_TYPE = 'LVDS')),
-			Subsignal('clk_en',  Pins('K4', dir = 'o')),
-			Subsignal('cs',      PinsN('M3', dir = 'o')),
-			Subsignal('we',      PinsN('E4', dir = 'o')),
-			Subsignal('ras',     PinsN('L1', dir = 'o')),
-			Subsignal('cas',     PinsN('M1', dir = 'o')),
-			Subsignal('a',       Pins('D5 F4 B3 F3 E5 C3 C4 A5 A3 B5 G3 F5 D2 A4 D3 E3', dir = 'o')),
-			Subsignal('ba',      Pins('B4 H5 N2', dir = 'o')),
-			Subsignal('dqs',     DiffPairs('K2 H4', 'J1 G5', dir = 'io'), Attrs(IO_TYPE = 'LVDS')),
-			Subsignal('dq',      Pins('G2 K1 F1 K3 H2 J3 G1 H1 B1 E1 A2 F2 C1 E2 C2 D1', dir = 'io')),
-			Subsignal('dm',      Pins('L4 J5', dir = 'o')),
-			Subsignal('odt',     Pins('C5', dir = 'o')),
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('P1', dir = 'o')),
+			Subsignal('clk', DiffPairs('M4', 'N5', dir = 'o'), Attrs(IO_TYPE = 'LVDS')),
+			Subsignal('clk_en', Pins('K4', dir = 'o')),
+			Subsignal('cs', PinsN('M3', dir = 'o')),
+			Subsignal('we', PinsN('E4', dir = 'o')),
+			Subsignal('ras', PinsN('L1', dir = 'o')),
+			Subsignal('cas', PinsN('M1', dir = 'o')),
+			Subsignal('a', Pins('D5 F4 B3 F3 E5 C3 C4 A5 A3 B5 G3 F5 D2 A4 D3 E3', dir = 'o')),
+			Subsignal('ba', Pins('B4 H5 N2', dir = 'o')),
+			Subsignal('dqs', DiffPairs('K2 H4', 'J1 G5', dir = 'io'), Attrs(IO_TYPE = 'LVDS')),
+			Subsignal('dq', Pins('G2 K1 F1 K3 H2 J3 G1 H1 B1 E1 A2 F2 C1 E2 C2 D1', dir = 'io')),
+			Subsignal('dm', Pins('L4 J5', dir = 'o')),
+			Subsignal('odt', Pins('C5', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_I')
 		)
 	]
 	connectors = [
-		Connector('P8', 0, '''
-		-   -   C20 D19 D20 E19 E20 F19 F20 G20 -   -   -   -   -   -
-		-   -   -   -   -   -   G19 H20 J20 K20 C18 D17 D18 E17 E18 F18
-		F17 G18 E16 F16 G16 H16 J17 J16 H18 H17 J19 K19 J18 K18
-		'''),
-		Connector('P9', 0, '''
-		-   -   -   -   -   -   -   -   -   -   -   A11 B11 A10 C10 A9
-		B9  C11 A8  -   -   D9  C8  B8  A7  A6  B6  D8  C7  D7  C6  D6
-		-   -   -   -   -   -   -   -   -   B10 E10 -   -   -
-		'''),
+		Connector(
+			'P8', 0,
+			' -   -   C20 D19 D20 E19 E20 F19 F20 G20 -   -   -   -   -   -   '
+			' -   -   -   -   -   -   G19 H20 J20 K20 C18 D17 D18 E17 E18 F18 '
+			' F17 G18 E16 F16 G16 H16 J17 J16 H18 H17 J19 K19 J18 K18 '
+		),
+		Connector(
+			'P9', 0,
+			'-   -   -   -   -   -   -   -   -   -   -   A11 B11 A10 C10 A9 '
+			'B9  C11 A8  -   -   D9  C8  B8  A7  A6  B6  D8  C7  D7  C6  D6 '
+			'-   -   -   -   -   -   -   -   -   B10 E10 -   -   - '
+		),
 	]
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:

--- a/torii_boards/lattice/ecp5/orangecrab_r0_1.py
+++ b/torii_boards/lattice/ecp5/orangecrab_r0_1.py
@@ -21,78 +21,81 @@ class OrangeCrabR0_1Platform(ECP5Platform):
 
 	resources   = [
 		Resource('clk', 0, Pins('A9', dir = 'i'), Clock(48e6), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# Used to reload FPGA configuration.
 		# Can enter USB bootloader by assigning button 0 to program.
 		Resource('program', 0, PinsN('R16', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33')),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'V17', g = 'T17', b = 'J3', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'U17', clk = 'U16', cipo = 'T18', copi = 'U18', wp_n = 'R18', hold_n = 'N18',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33'),
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',     PinsN('B1', dir = 'o')),
-			Subsignal('clk',     DiffPairs('J18', 'K18', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
-			Subsignal('clk_en',  Pins('D6', dir = 'o')),
-			Subsignal('cs',      PinsN('A12', dir = 'o')),
-			Subsignal('we',      PinsN('B12', dir = 'o')),
-			Subsignal('ras',     PinsN('C12', dir = 'o')),
-			Subsignal('cas',     PinsN('D13', dir = 'o')),
-			Subsignal('a',       Pins('A4 D2 C3 C7 D3 D4 D1 B2 C1 A2 A7 C2 C4', dir = 'o')),
-			Subsignal('ba',      Pins('B6 B7 A6', dir = 'o')),
-			Subsignal('dqs',     DiffPairs('G18 H17', 'B15 A16', dir = 'io'),
+		# TODO(aki): Replace with DDR3Resource
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('B1', dir = 'o')),
+			Subsignal('clk', DiffPairs('J18', 'K18', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
+			Subsignal('clk_en', Pins('D6', dir = 'o')),
+			Subsignal('cs', PinsN('A12', dir = 'o')),
+			Subsignal('we', PinsN('B12', dir = 'o')),
+			Subsignal('ras', PinsN('C12', dir = 'o')),
+			Subsignal('cas', PinsN('D13', dir = 'o')),
+			Subsignal('a', Pins('A4 D2 C3 C7 D3 D4 D1 B2 C1 A2 A7 C2 C4', dir = 'o')),
+			Subsignal('ba', Pins('B6 B7 A6', dir = 'o')),
+			Subsignal(
+				'dqs',
+				DiffPairs('G18 H17', 'B15 A16', dir = 'io'),
 				Attrs(IO_TYPE = 'SSTL135D_I', TERMINATION = 'OFF', DIFFRESISTOR = '100')
 			),
-			Subsignal('dq',      Pins('F17 F16 G15 F15 J16 C18 H16 F18 C17 D15 B17 C16 A15 B13 A17 A13', dir = 'io'),
+			Subsignal(
+				'dq',
+				Pins('F17 F16 G15 F15 J16 C18 H16 F18 C17 D15 B17 C16 A15 B13 A17 A13', dir = 'io'),
 				Attrs(TERMINATION = '75')
 			),
-			Subsignal('dm',      Pins('G16 D16', dir = 'o')),
-			Subsignal('odt',     Pins('C13', dir = 'o')),
+			Subsignal('dm', Pins('G16 D16', dir = 'o')),
+			Subsignal('odt', Pins('C13', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_I', SLEWRATE = 'FAST')
 		),
-
-		Resource('ddr3_pseudo_power', 0,
+		Resource(
+			'ddr3_pseudo_power', 0,
 			# pseudo power pins, leave these at their default value
 			Subsignal('vcc_virtual', PinsN('A3 B18 C6 C15 D17 D18 K15 K16 K17', dir = 'o')),
 			Subsignal('gnd_virtual', Pins('L15 L16 L18', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_II', SLEWRATE = 'FAST')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			dat0 = 'J1', dat1 = 'K3', dat2 = 'L3', dat3 = 'M1', clk = 'K1', cmd = 'K2', cd = 'L1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'FAST')
 		),
-
 		DirectUSBResource(0, d_p = 'N1', d_n = 'M2', pullup = 'N2', attrs = Attrs(IO_TYPE = 'LVCMOS33'))
 	]
 	connectors = [
 		Connector('io', 0, {
-			'0':    'N17',
-			'1':    'M18',
-			'5':    'B10',
-			'6':    'B9',
-			'9':    'C8',
-			'10':   'B8',
-			'11':   'A8',
-			'12':   'H2',
-			'13':   'J2',
+			'0': 'N17',
+			'1': 'M18',
+			'5': 'B10',
+			'6': 'B9',
+			'9': 'C8',
+			'10': 'B8',
+			'11': 'A8',
+			'12': 'H2',
+			'13': 'J2',
 			'cipo': 'N15',
 			'copi': 'N16',
-			'sck':  'R17',
-			'scl':  'C9',
-			'sda':  'C10'
+			'sck': 'R17',
+			'scl': 'C9',
+			'sda': 'C10'
 		}),
 		Connector('mcu', 0, {
-			'0':    'A10',
-			'1':    'C11',
-			'2':    'A11',
-			'3':    'B11',
+			'0': 'A10',
+			'1': 'C11',
+			'2': 'A11',
+			'3': 'B11',
 		}),
 	]
 
@@ -105,10 +108,7 @@ class OrangeCrabR0_1Platform(ECP5Platform):
 	@property
 	def command_templates(self) -> list[str]:
 		return super().command_templates + [
-			r'''
-			{{invoke_tool('dfu-suffix')}}
-				-v 1209 -p 5af0 -a {{name}}.bit
-			'''
+			r'''{{invoke_tool('dfu-suffix')}} -v 1209 -p 5af0 -a {{name}}.bit'''
 		]
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:

--- a/torii_boards/lattice/ecp5/orangecrab_r0_2.py
+++ b/torii_boards/lattice/ecp5/orangecrab_r0_2.py
@@ -29,90 +29,92 @@ class OrangeCrabR0_2Platform(ECP5Platform):
 
 	resources   = [
 		Resource('clk', 0, Pins('A9', dir = 'i'), Clock(48e6), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# Used to reload FPGA configuration.
 		# Can enter USB bootloader by assigning button 0 to program.
 		Resource('program', 0, PinsN('V17', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33')),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'K4', g = 'M3', b = 'J3', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		*ButtonResources(
 			pins = {0: 'J17' }, invert = True,
 			attrs = Attrs(IO_TYPE = 'SSTL135_I')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'U17', clk = 'U16', cipo = 'T18', copi = 'U18', wp_n = 'R18', hold_n = 'N18',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33'),
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',     PinsN('L18', dir = 'o')),
-			Subsignal('clk',     DiffPairs('J18', 'K18', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
-			Subsignal('clk_en',  Pins('D18', dir = 'o')),
-			Subsignal('cs',      PinsN('A12', dir = 'o')),
-			Subsignal('we',      PinsN('B12', dir = 'o')),
-			Subsignal('ras',     PinsN('C12', dir = 'o')),
-			Subsignal('cas',     PinsN('D13', dir = 'o')),
-			Subsignal('a',       Pins('C4 D2 D3 A3 A4 D4 C3 B2 B1 D1 A7 C2 B6 C1 A2 C7', dir = 'o')),
-			Subsignal('ba',      Pins('P5 N3 M3', dir = 'o')),
-			Subsignal('dqs',     DiffPairs('G18 H17', 'B15 A16', dir = 'io'),
-				Attrs(IO_TYPE = 'SSTL135D_I', TERMINATION = 'OFF',
-				DIFFRESISTOR = '100')
+		# TODO(aki): Replace with DDR3Resource
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('L18', dir = 'o')),
+			Subsignal('clk', DiffPairs('J18', 'K18', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
+			Subsignal('clk_en', Pins('D18', dir = 'o')),
+			Subsignal('cs', PinsN('A12', dir = 'o')),
+			Subsignal('we', PinsN('B12', dir = 'o')),
+			Subsignal('ras', PinsN('C12', dir = 'o')),
+			Subsignal('cas', PinsN('D13', dir = 'o')),
+			Subsignal('a', Pins('C4 D2 D3 A3 A4 D4 C3 B2 B1 D1 A7 C2 B6 C1 A2 C7', dir = 'o')),
+			Subsignal('ba', Pins('P5 N3 M3', dir = 'o')),
+			Subsignal(
+				'dqs',
+				DiffPairs('G18 H17', 'B15 A16', dir = 'io'),
+				Attrs(IO_TYPE = 'SSTL135D_I', TERMINATION = 'OFF', DIFFRESISTOR = '100')
 			),
-			Subsignal('dq',      Pins('C17 D15 B17 C16 A15 B13 A17 A13 F17 F16 G15 F15 J16 C18 H16 F18', dir = 'io'),
+			Subsignal(
+				'dq',
+				Pins('C17 D15 B17 C16 A15 B13 A17 A13 F17 F16 G15 F15 J16 C18 H16 F18', dir = 'io'),
 				Attrs(TERMINATION = '75')
 			),
-			Subsignal('dm',      Pins('G16 D16', dir = 'o')),
-			Subsignal('odt',     Pins('C13', dir = 'o')),
+			Subsignal('dm', Pins('G16 D16', dir = 'o')),
+			Subsignal('odt', Pins('C13', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_I', SLEWRATE = 'FAST')
 		),
-
-		Resource('ddr3_pseudo_power', 0,
+		Resource(
+			'ddr3_pseudo_power', 0,
 			# pseudo power pins, leave these at their default value
 			Subsignal('vcc_virtual', PinsN('K16 D17 K15 K17 B18 C6', dir = 'o')),
 			Subsignal('gnd_virtual', Pins('L15 L16', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_II', SLEWRATE = 'FAST')
 		),
-
-		Resource('adc', 0,
-			Subsignal('ctrl',     Pins('G1 F1', dir = 'o')),
-			Subsignal('mux',      Pins('F4 F3 F2 H1', dir = 'o')),
-			Subsignal('sense',    DiffPairs('H3', 'G3', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33D')),
+		Resource(
+			'adc', 0,
+			Subsignal('ctrl', Pins('G1 F1', dir = 'o')),
+			Subsignal('mux', Pins('F4 F3 F2 H1', dir = 'o')),
+			Subsignal('sense', DiffPairs('H3', 'G3', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33D')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			dat0 = 'J1', dat1 = 'K3', dat2 = 'L3', dat3 = 'M1', clk = 'K1', cmd = 'K2', cd = 'L1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'FAST')
 		),
-
 		DirectUSBResource(0, d_p = 'N1', d_n = 'M2', pullup = 'N2', attrs = Attrs(IO_TYPE = 'LVCMOS33'))
 	]
+
 	connectors = [
 		Connector('io', 0, {
-			'0':    'N17',
-			'1':    'M18',
-			'5':    'B10',
-			'6':    'B9',
-			'9':    'C8',
-			'10':   'B8',
-			'11':   'A8',
-			'12':   'H2',
-			'13':   'J2',
-			'a0':   'L4',
-			'a1':   'N3',
-			'a2':   'N4',
-			'a3':   'H4',
-			'a4':   'G4',
+			'0': 'N17',
+			'1': 'M18',
+			'5': 'B10',
+			'6': 'B9',
+			'9': 'C8',
+			'10': 'B8',
+			'11': 'A8',
+			'12': 'H2',
+			'13': 'J2',
+			'a0': 'L4',
+			'a1': 'N3',
+			'a2': 'N4',
+			'a3': 'H4',
+			'a4': 'G4',
 			'cipo': 'N15',
 			'copi': 'N16',
-			'sck':  'R17',
-			'scl':  'C9',
-			'sda':  'C10'
+			'sck': 'R17',
+			'scl': 'C9',
+			'sda': 'C10'
 		})
 	]
 
@@ -125,10 +127,7 @@ class OrangeCrabR0_2Platform(ECP5Platform):
 	@property
 	def command_templates(self) -> list[str]:
 		return super().command_templates + [
-			r'''
-			{{invoke_tool('dfu-suffix')}}
-				-v 1209 -p 5af0 -a {{name}}.bit
-			'''
+			r'''{{invoke_tool('dfu-suffix')}} -v 1209 -p 5af0 -a {{name}}.bit'''
 		]
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:

--- a/torii_boards/lattice/ecp5/supercon19badge.py
+++ b/torii_boards/lattice/ecp5/supercon19badge.py
@@ -50,10 +50,8 @@ class Supercon19BadgePlatform(ECP5Platform):
 
 	resources   = [
 		Resource('clk8', 0, Pins('U18'), Clock(8e6), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# Used to trigger FPGA reconfiguration.
 		Resource('program', 0, PinsN('R1'), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# See note above for LED anode/cathode information.
 		# Short version is: these work as normal LEDs until you touch their cathodes.
 		*LEDResources(
@@ -61,84 +59,85 @@ class Supercon19BadgePlatform(ECP5Platform):
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		Resource('led_cathodes', 0, Pins('P19 L18 K18'), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		UARTResource(0, rx = 'U2', tx = 'U1', attrs = Attrs(IO_TYPE = 'LVCMOS33')),
-
-		DirectUSBResource(0,
+		DirectUSBResource(
+			0,
 			d_p = 'F3', d_n = 'G3', pullup = 'E4', vbus_valid = 'F4',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# Buttons, with semantic aliases.
 		*ButtonResources(
 			pins = 'G2 F2 F1 C1 E1 D2 D1 E2',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-		Resource('keypad', 0,
-			Subsignal('left',   Pins('G2', dir = 'i')),
-			Subsignal('right',  Pins('F2', dir = 'i')),
-			Subsignal('up',     Pins('F1', dir = 'i')),
-			Subsignal('down',   Pins('C1', dir = 'i')),
-			Subsignal('start',  Pins('E1', dir = 'i')),
+		Resource(
+			'keypad', 0,
+			Subsignal('left', Pins('G2', dir = 'i')),
+			Subsignal('right', Pins('F2', dir = 'i')),
+			Subsignal('up', Pins('F1', dir = 'i')),
+			Subsignal('down', Pins('C1', dir = 'i')),
+			Subsignal('start', Pins('E1', dir = 'i')),
 			Subsignal('select', Pins('D2', dir = 'i')),
-			Subsignal('a',      Pins('D1', dir = 'i')),
-			Subsignal('b',      Pins('E2', dir = 'i')),
+			Subsignal('a', Pins('D1', dir = 'i')),
+			Subsignal('b', Pins('E2', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-
 		# Direct HDMI on the bottom of the board.
-		Resource('hdmi', 0,
+		Resource(
+			'hdmi', 0,
 			Subsignal('clk', DiffPairsN('P20', 'R20'), Attrs(IO_TYPE = 'TMDS_33')),
 			Subsignal('d', DiffPairs('N19 L20 L16', 'N20 M20 L17'), Attrs(IO_TYPE = 'TMDS_33')),
 			Subsignal('hpd', PinsN('R18'), Attrs(IO_TYPE = 'LVCMOS33')), # Also called HDMI_HEAC_n
 			Subsignal('hdmi_heac_p', PinsN('T19'), Attrs(IO_TYPE = 'LVCMOS33')),
 			Attrs(DRIVE = '4'),
 		),
-
-		Resource('lcd', 0,
-			Subsignal('db',
-				Pins('J3 H1 K4 J1 K3 K2 L4 K1 L3 L2 M4 L1 M3 M1 N4 N2 N3 N1'),
-			),
-			Subsignal('rd',    Pins('P2')),
-			Subsignal('wr',    Pins('P4')),
-			Subsignal('rs',    Pins('P1')),
-			Subsignal('cs',    Pins('P3')),
-			Subsignal('id',    Pins('J4')),
-			Subsignal('rst',   Pins('H2')),
+		# TODO(aki): Replace with LCDResource
+		Resource(
+			'lcd', 0,
+			Subsignal('db', Pins('J3 H1 K4 J1 K3 K2 L4 K1 L3 L2 M4 L1 M3 M1 N4 N2 N3 N1')),
+			Subsignal('rd', Pins('P2')),
+			Subsignal('wr', Pins('P4')),
+			Subsignal('rs', Pins('P1')),
+			Subsignal('cs', Pins('P3')),
+			Subsignal('id', Pins('J4')),
+			Subsignal('rst', Pins('H2')),
 			Subsignal('fmark', Pins('G1')),
-			Subsignal('blen',  Pins('P5')),
+			Subsignal('blen', Pins('P5')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		Resource('spi_flash', 0, # clock needs to be accessed through USRMCLK
-			Subsignal('cs',   PinsN('R2')),
+		Resource(
+			'spi_flash', 0, # clock needs to be accessed through USRMCLK
+			Subsignal('cs', PinsN('R2')),
 			Subsignal('copi', Pins('W2')),
 			Subsignal('cipo', Pins('V2')),
-			Subsignal('wp',   Pins('Y2')),
+			Subsignal('wp', Pins('Y2')),
 			Subsignal('hold', Pins('W1')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-		Resource('spi_flash_4x', 0, # clock needs to be accessed through USRMCLK
-			Subsignal('cs',   PinsN('R2')),
-			Subsignal('dq',   Pins('W2 V2 Y2 W1')),
+		Resource(
+			'spi_flash_4x', 0, # clock needs to be accessed through USRMCLK
+			Subsignal('cs', PinsN('R2')),
+			Subsignal('dq', Pins('W2 V2 Y2 W1')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		# SPI-connected PSRAM.
-		Resource('spi_psram_4x', 0,
-			Subsignal('cs',  PinsN('D20')),
+		Resource(
+			'spi_psram_4x', 0,
+			Subsignal('cs', PinsN('D20')),
 			Subsignal('clk', Pins('E20')),
-			Subsignal('dq',  Pins('E19 D19 C20 F19'), Attrs(PULLMODE = 'UP')),
+			Subsignal('dq', Pins('E19 D19 C20 F19'), Attrs(PULLMODE = 'UP')),
 			Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'SLOW')
 		),
-		Resource('spi_psram_4x', 1,
-			Subsignal('cs',   PinsN('F20')),
-			Subsignal('clk',  Pins('J19')),
-			Subsignal('dq',   Pins('J20 G19 G20 H20'), Attrs(PULLMODE = 'UP')),
+		Resource(
+			'spi_psram_4x', 1,
+			Subsignal('cs', PinsN('F20')),
+			Subsignal('clk', Pins('J19')),
+			Subsignal('dq', Pins('J20 G19 G20 H20'), Attrs(PULLMODE = 'UP')),
 			Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'SLOW')
 		),
-
-		SDRAMResource(0, clk = 'D11', cke = 'C11', cs_n = 'C7', we_n = 'B6', ras_n = 'D6', cas_n = 'A6',
+		SDRAMResource(
+			0,
+			clk = 'D11', cke = 'C11', cs_n = 'C7', we_n = 'B6', ras_n = 'D6', cas_n = 'A6',
 			ba = 'A7 C8', a = 'A8 D9 C9 B9 C14 E17 A12 B12 H17 G18 B8 A11 B11',
 			dq = 'C5 B5 A5 C6 B10 C10 D10 A9', dqm = 'A10',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'FAST')
@@ -147,19 +146,19 @@ class Supercon19BadgePlatform(ECP5Platform):
 
 	connectors = [
 		Connector('pmod', 0, 'A15 C16 A14 D16 B15 C15 A13 B13'),
-		Connector('cartridge', 0,
-			'- - - - - - - - C5 B5 A5 C6 B6 A6 D6 C7 A7 C8 B8 A8 D9 C9 B9 A9' # continued:
-			' D10 C10 B10 A10 D11 C11 B11 A11 G18 H17 B12 A12 E17 C14'
+		Connector(
+			'cartridge', 0,
+			'-   -   -   -   -   -   -   -   C5  B5  A5  C6  B6  A6  D6  C7  A7  C8  B8 '
+			'A8  D9  C9  B9  A9  D10 C10 B10 A10 D11 C11 B11 A11 G18 H17 B12 A12 E17 C14'
 		),
-
 		# SAO connectors names are compliant with the, erm, SAO 1.69 X-TREME standard.
 		# See: https://hackaday.com/2019/03/20/introducing-the-shitty-add-on-v1-69bis-standard/
 		Connector('sao', 0, {
-			'sda':   'B3', 'scl':   'B2', 'gpio0': 'A2',
+			'sda': 'B3', 'scl': 'B2', 'gpio0': 'A2',
 			'gpio1': 'A3', 'gpio2': 'B4', 'gpio3': 'A4'
 		}),
 		Connector('sao', 1, {
-			'sda':   'A16', 'scl':   'B17', 'gpio0': 'B18',
+			'sda': 'A16', 'scl': 'B17', 'gpio0': 'B18',
 			'gpio1': 'A17', 'gpio2': 'B16', 'gpio3': 'C17'
 		})
 	]

--- a/torii_boards/lattice/ecp5/ulx3s.py
+++ b/torii_boards/lattice/ecp5/ulx3s.py
@@ -22,91 +22,94 @@ class _ULX3SPlatform(ECP5Platform):
 
 	resources   = [
 		Resource('clk25', 0, Pins('G2', dir = 'i'), Clock(25e6), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# Used to reload FPGA configuration.
 		Resource('program', 0, PinsN('M4', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')),
-
-		*LEDResources(pins = 'B2 C2 C1 D2 D1 E2 E1 H3',
-			attrs = Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4')),
-		*ButtonResources(pins = 'R1 T1 R18 V1 U1 H16',
+		*LEDResources(
+			pins = 'B2 C2 C1 D2 D1 E2 E1 H3',
+			attrs = Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4')
+		),
+		*ButtonResources(
+			pins = 'R1 T1 R18 V1 U1 H16',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')
 		),
-		*ButtonResources('switch', pins = 'E8 D8 D7 E7',
+		*ButtonResources(
+			'switch',
+			pins = 'E8 D8 D7 E7',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')
 		),
-
 		# Semantic aliases by button label.
-		Resource('button_pwr',   0, PinsN('D6', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')),
-		Resource('button_fire',  0, Pins('R1',  dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
-		Resource('button_fire',  1, Pins('T1',  dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
-		Resource('button_up'                ,    0, Pins('R18', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
-		Resource('button_down',  0, Pins('V1',  dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
-		Resource('button_left',  0, Pins('U1',  dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
+		Resource('button_pwr', 0, PinsN('D6', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')),
+		Resource('button_fire', 0, Pins('R1', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
+		Resource('button_fire', 1, Pins('T1', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
+		Resource('button_up', 0, Pins('R18', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
+		Resource('button_down', 0, Pins('V1', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
+		Resource('button_left', 0, Pins('U1', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
 		Resource('button_right', 0, Pins('H16', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'DOWN')),
-
 		# FTDI connection.
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'M1', tx = 'L4', rts = 'M3', dtr = 'N1', role = 'dce',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		Resource('uart_tx_enable', 0, Pins('L3', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33')),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'J1', cmd = 'J3', dat0 = 'K2', dat1 = 'K1', dat2 = 'H2', dat3 = 'H1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEW = 'FAST')
 		),
-
+		# TODO(aki): Replace with SPIFlashResource
 		# SPI Flash clock is accessed via USR_MCLK instance.
-		Resource('spi_flash', 0,
-			Subsignal('cs',   PinsN('R2', dir = 'o')),
+		Resource(
+			'spi_flash', 0,
+			Subsignal('cs', PinsN('R2', dir = 'o')),
 			Subsignal('copi', Pins('W2', dir = 'o')),
 			Subsignal('cipo', Pins('V2', dir = 'i')),
 			Subsignal('hold', PinsN('W1', dir = 'o')),
-			Subsignal('wp',   PinsN('Y2', dir = 'o')),
+			Subsignal('wp', PinsN('Y2', dir = 'o')),
 			Attrs(PULLMODE = 'NONE', DRIVE = '4', IO_TYPE = 'LVCMOS33')
 		),
-
-		SDRAMResource(0,
+		SDRAMResource(
+			0,
 			clk = 'F19', cke = 'F20', cs_n = 'P20', we_n = 'T20', cas_n = 'T19', ras_n = 'R20', dqm = 'U19 E20',
 			ba = 'P19 N20', a = 'M20 M19 L20 L19 K20 K19 K18 J20 J19 H20 N19 G20 G19',
 			dq = 'J16 L18 M18 N18 P18 T18 T17 U20 E19 D20 D19 C20 E18 F18 J18 J17',
 			attrs = Attrs(PULLMODE = 'NONE', DRIVE = '4', SLEWRATE = 'FAST', IO_TYPE = 'LVCMOS33')
 		),
-
 		# SPI bus for ADC.
-		SPIResource('adc', 0, cs_n = 'R17', copi = 'R16', cipo = 'U16', clk = 'P17',
-			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')),
-
+		SPIResource(
+			'adc', 0,
+			cs_n = 'R17', copi = 'R16', cipo = 'U16', clk = 'P17',
+			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
+		),
 		# TRRS audio jack
-		Resource('audio', 0,
+		Resource(
+			'audio', 0,
 			Subsignal('l', Pins('E4 D3 C3 B3', dir = 'o')),
 			Subsignal('r', Pins('A3 B5 D5 C5', dir = 'o')),
 			Subsignal('ring2', Pins('H5 F2 F5 E5', dir = 'o')), # extra ring out for video adapters
 		),
-
 		# ESP-32 connections
-		Resource('esp32', 0,
-			Subsignal('en',     Pins('F1', dir = 'o'), Attrs(PULLMODE = 'UP')),
-			Subsignal('tx',     Pins('K3', dir = 'o'), Attrs(PULLMODE = 'UP')),
-			Subsignal('rx',     Pins('K4', dir = 'i'), Attrs(PULLMODE = 'UP')),
-			Subsignal('gpio0',  Pins('L2'),          Attrs(PULLMODE = 'UP')),
-			Subsignal('gpio5',  Pins('N4')),
-			Subsignal('gpio16', Pins('L1'),          Attrs(PULLMODE = 'UP')),
-			Subsignal('gpio17', Pins('N3'),          Attrs(PULLMODE = 'UP')),
+		Resource(
+			'esp32', 0,
+			Subsignal('en', Pins('F1', dir = 'o'), Attrs(PULLMODE = 'UP')),
+			Subsignal('tx', Pins('K3', dir = 'o'), Attrs(PULLMODE = 'UP')),
+			Subsignal('rx', Pins('K4', dir = 'i'), Attrs(PULLMODE = 'UP')),
+			Subsignal('gpio0', Pins('L2'), Attrs(PULLMODE = 'UP')),
+			Subsignal('gpio5', Pins('N4')),
+			Subsignal('gpio16', Pins('L1'), Attrs(PULLMODE = 'UP')),
+			Subsignal('gpio17', Pins('N3'), Attrs(PULLMODE = 'UP')),
 			Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4')
 		),
-
 		# PCB antenna, tuned to 433MHz
 		Resource('ant', 0, Pins('G1', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# Differential versions of our connector I/O.
 		Resource('diff_gpio', 0, DiffPairs('B11', 'C11'), Attrs(IO_TYPE = 'LVCMOS33')),
 		Resource('diff_gpio', 1, DiffPairs('A10', 'A11'), Attrs(IO_TYPE = 'LVCMOS33')),
 		Resource('diff_gpio', 2, DiffPairs('A9', 'B10'), Attrs(IO_TYPE = 'LVCMOS33')),
 		Resource('diff_gpio', 3, DiffPairs('B9', 'C10'),  Attrs(IO_TYPE = 'LVCMOS33')),
-
 		# HDMI (only TX, due to the top bank of ECP5 only supporting diff. outputs)
-		Resource('hdmi', 0,
+		Resource(
+			'hdmi', 0,
 			Subsignal(
 				'cec', Pins('A18', dir = 'io'),
 				Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4', PULLMODE = 'UP')
@@ -132,8 +135,8 @@ class _ULX3SPlatform(ECP5Platform):
 				Attrs(IO_TYPE = 'LVCMOS33', DRIVE = '4', PULLMODE = 'UP')
 			)
 		),
-
-		DirectUSBResource(0,
+		DirectUSBResource(
+			0,
 			d_p = 'D15', d_n = 'E15', pullup = 'B12',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		)
@@ -141,13 +144,13 @@ class _ULX3SPlatform(ECP5Platform):
 
 	connectors = [
 		Connector('gpio', 0, {
-			'0+': 'B11',  '0-':  'C11', '1+':  'A10', '1-':  'A11',
-			'2+': 'A9',   '2-':  'B10', '3+':  'B9',  '3-':  'C10',
-			'4+': 'A7',   '4-':  'A8',  '5+':  'C8',  '5-':  'B8',
-			'6+': 'C6',   '6-':  'C7',  '7+':  'A6',  '7-':  'B6',
-			'8+': 'A4',   '8-':  'A5',  '9+':  'A2',  '9-':  'B1',
-			'10+': 'C4',  '10-': 'B4',  '11+': 'F4',  '11-': 'E3',
-			'12+': 'G3',  '12-': 'F3',  '13+': 'H4',  '13-': 'G5',
+			'0+': 'B11', '0-': 'C11', '1+': 'A10', '1-': 'A11',
+			'2+': 'A9', '2-': 'B10', '3+': 'B9', '3-': 'C10',
+			'4+': 'A7', '4-': 'A8', '5+': 'C8', '5-': 'B8',
+			'6+': 'C6', '6-': 'C7', '7+': 'A6', '7-': 'B6',
+			'8+': 'A4', '8-': 'A5', '9+': 'A2', '9-': 'B1',
+			'10+': 'C4', '10-': 'B4', '11+': 'F4', '11-': 'E3',
+			'12+': 'G3', '12-': 'F3', '13+': 'H4', '13-': 'G5',
 			'14+': 'U18', '14-': 'U17', '15+': 'N17', '15-': 'P16',
 			'16+': 'N16', '16-': 'M17', '17+': 'L16', '17-': 'L17',
 			'18+': 'H18', '18-': 'H17', '19+': 'F17', '19-': 'G18',

--- a/torii_boards/lattice/ecp5/versa_ecp5.py
+++ b/torii_boards/lattice/ecp5/versa_ecp5.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                           import dedent
+
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildProducts
 from torii.platform.resources           import LEDResources, SPIFlashResources, SwitchResources, UARTResource
@@ -23,13 +25,12 @@ class VersaECP5Platform(ECP5Platform):
 		Resource('rst', 0, PinsN('T1', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33')),
 		Resource('clk100', 0, DiffPairs('P3', 'P4', dir = 'i'), Clock(100e6), Attrs(IO_TYPE = 'LVDS')),
 		Resource('pclk', 0, DiffPairs('A4', 'A5', dir = 'i'), Attrs(IO_TYPE = 'LVDS')),
-
 		*LEDResources(
 			pins = 'E16 D17 D18 E18 F17 F18 E17 F16', invert = True,
 			attrs = Attrs(IO_TYPE = 'LVCMOS25')
 		),
-
-		Resource('alnum_led', 0,
+		Resource(
+			'alnum_led', 0,
 			Subsignal('a', PinsN('M20', dir = 'o')),
 			Subsignal('b', PinsN('L18', dir = 'o')),
 			Subsignal('c', PinsN('M19', dir = 'o')),
@@ -47,7 +48,6 @@ class VersaECP5Platform(ECP5Platform):
 			Subsignal('dp', PinsN('U1', dir = 'o')),
 			Attrs(IO_TYPE = 'LVCMOS25')
 		),
-
 		*SwitchResources(
 			pins = {0: 'H2',  1: 'K3',  2: 'G3',  3: 'F2' },
 			attrs = Attrs(IO_TYPE = 'LVCMOS15')
@@ -56,106 +56,112 @@ class VersaECP5Platform(ECP5Platform):
 			pins = {4: 'J18', 5: 'K18', 6: 'K19', 7: 'K20'},
 			attrs = Attrs(IO_TYPE = 'LVCMOS25')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'C11', tx = 'A11',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'R2', clk = 'U3', cipo = 'W2', copi = 'V2', wp_n = 'Y2', hold_n = 'W1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 		Resource(
 			'eth_clk125', 0, Pins('L19', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		),
 		Resource(
 			'eth_clk125_pll', 0, Pins('U16', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		), # NC by default
-		Resource('eth_rgmii', 0,
-			Subsignal('rst',     PinsN('U17', dir = 'o')),
-			Subsignal('mdc',     Pins('T18', dir = 'o')),
-			Subsignal('mdio',    Pins('U18', dir = 'io')),
-			Subsignal('tx_clk',  Pins('P19', dir = 'o')),
-			Subsignal('tx_ctl',  Pins('R20', dir = 'o')),
+		# TODO(aki): Replace with EthernetResource
+		Resource(
+			'eth_rgmii', 0,
+			Subsignal('rst', PinsN('U17', dir = 'o')),
+			Subsignal('mdc', Pins('T18', dir = 'o')),
+			Subsignal('mdio', Pins('U18', dir = 'io')),
+			Subsignal('tx_clk', Pins('P19', dir = 'o')),
+			Subsignal('tx_ctl', Pins('R20', dir = 'o')),
 			Subsignal('tx_data', Pins('N19 N20 P18 P20', dir = 'o')),
-			Subsignal('rx_clk',  Pins('L20', dir = 'i')),
-			Subsignal('rx_ctl',  Pins('U19', dir = 'i')),
+			Subsignal('rx_clk', Pins('L20', dir = 'i')),
+			Subsignal('rx_ctl', Pins('U19', dir = 'i')),
 			Subsignal('rx_data', Pins('T20 U20 T19 R18', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS25')
 		),
-		Resource('eth_sgmii', 0,
-			Subsignal('rst',  PinsN('U17', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
-			Subsignal('mdc',  Pins('T18', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
+		Resource(
+			'eth_sgmii', 0,
+			Subsignal('rst', PinsN('U17', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
+			Subsignal('mdc', Pins('T18', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
 			Subsignal('mdio', Pins('U18', dir = 'io'), Attrs(IO_TYPE = 'LVCMOS25')),
-			Subsignal('tx',   DiffPairs('W13', 'W14', dir = 'o')),
-			Subsignal('rx',   DiffPairs('Y14', 'Y15', dir = 'i')),
+			Subsignal('tx', DiffPairs('W13', 'W14', dir = 'o')),
+			Subsignal('rx', DiffPairs('Y14', 'Y15', dir = 'i')),
 		),
-
 		Resource(
 			'eth_clk125', 1, Pins('J20', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		),
 		Resource(
 			'eth_clk125_pll', 1, Pins('C18', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		), # NC by default
-		Resource('eth_rgmii', 1,
-			Subsignal('rst',     PinsN('F20', dir = 'o')),
-			Subsignal('mdc',     Pins('G19', dir = 'o')),
-			Subsignal('mdio',    Pins('H20', dir = 'io')),
-			Subsignal('tx_clk',  Pins('C20', dir = 'o')),
+		Resource(
+			'eth_rgmii', 1,
+			Subsignal('rst', PinsN('F20', dir = 'o')),
+			Subsignal('mdc', Pins('G19', dir = 'o')),
+			Subsignal('mdio', Pins('H20', dir = 'io')),
+			Subsignal('tx_clk', Pins('C20', dir = 'o')),
 			Subsignal('tx_ctrl', Pins('E19', dir = 'o')),
 			Subsignal('tx_data', Pins('J17 J16 D19 D20', dir = 'o')),
-			Subsignal('rx_clk',  Pins('J19', dir = 'i')),
+			Subsignal('rx_clk', Pins('J19', dir = 'i')),
 			Subsignal('rx_ctrl', Pins('F19', dir = 'i')),
 			Subsignal('rx_data', Pins('G18 G16 H18 H17', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS25')
 		),
-		Resource('eth_sgmii', 1,
-			Subsignal('rst',  PinsN('F20', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
-			Subsignal('mdc',  Pins('G19', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
+		Resource(
+			'eth_sgmii', 1,
+			Subsignal('rst', PinsN('F20', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
+			Subsignal('mdc', Pins('G19', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
 			Subsignal('mdio', Pins('H20', dir = 'io'), Attrs(IO_TYPE = 'LVCMOS25')),
-			Subsignal('tx',   DiffPairs('W17', 'W18', dir = 'o')),
-			Subsignal('rx',   DiffPairs('Y16', 'Y17', dir = 'i')),
+			Subsignal('tx', DiffPairs('W17', 'W18', dir = 'o')),
+			Subsignal('rx', DiffPairs('Y16', 'Y17', dir = 'i')),
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',    PinsN('N4', dir = 'o')),
-			Subsignal('clk',    DiffPairs('M4', 'N5', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('N4', dir = 'o')),
+			Subsignal('clk', DiffPairs('M4', 'N5', dir = 'o'), Attrs(IO_TYPE = 'SSTL135D_I')),
 			Subsignal('clk_en', Pins('N2', dir = 'o')),
-			Subsignal('cs',     PinsN('K1', dir = 'o')),
-			Subsignal('we',     PinsN('M1', dir = 'o')),
-			Subsignal('ras',    PinsN('P1', dir = 'o')),
-			Subsignal('cas',    PinsN('L1', dir = 'o')),
-			Subsignal('a',      Pins('P2 C4 E5 F5 B3 F4 B5 E4 C5 E3 D5 B4 C3', dir = 'o')),
-			Subsignal('ba',     Pins('P5 N3 M3', dir = 'o')),
+			Subsignal('cs', PinsN('K1', dir = 'o')),
+			Subsignal('we', PinsN('M1', dir = 'o')),
+			Subsignal('ras', PinsN('P1', dir = 'o')),
+			Subsignal('cas', PinsN('L1', dir = 'o')),
+			Subsignal('a', Pins('P2 C4 E5 F5 B3 F4 B5 E4 C5 E3 D5 B4 C3', dir = 'o')),
+			Subsignal('ba', Pins('P5 N3 M3', dir = 'o')),
 			Subsignal(
-				'dqs',    DiffPairs('K2 H4', 'J1 G5', dir = 'io'),
+				'dqs', DiffPairs('K2 H4', 'J1 G5', dir = 'io'),
 				Attrs(IO_TYPE = 'SSTL135D_I', DIFFRESISTOR = '100', TERMINATION = 'OFF')
 			),
-			Subsignal('dq',     Pins('L5 F1 K4 G1 L4 H1 G2 J3 D1 C1 E2 C2 F3 A2 E1 B1', dir = 'io')),
-			Attrs(TERMINATION = '75'),
-			Subsignal('dm',     Pins('J4 H5', dir = 'o')),
-			Subsignal('odt',    Pins('L2', dir = 'o')),
+			Subsignal(
+				'dq', Pins('L5 F1 K4 G1 L4 H1 G2 J3 D1 C1 E2 C2 F3 A2 E1 B1', dir = 'io'), Attrs(TERMINATION = '75')
+			),
+			Subsignal('dm', Pins('J4 H5', dir = 'o')),
+			Subsignal('odt', Pins('L2', dir = 'o')),
 			Attrs(IO_TYPE = 'SSTL135_I', SLEWRATE = 'FAST')
 		)
 	]
 	connectors = [
-		Connector('expcon', 1, '''
-		-   -   -   B19 B12 B9  E6  D6  E7  D7  B11 B6  E9  D9  B8  C8  D8  E8  C7  C6
-		-   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -
-		'''), # X3
-		Connector('expcon', 2, '''
-		A8  -   A12 A13 B13 C13 D13 E13 A14 C14 D14 E14 D11 C10 A9  B10 D12 E12 -   -
-		B15 -   C15 -   D15 -   E15 A16 B16 -   C16 D16 B17 -   C17 A17 B18 A7  A18 -
-		'''), # X4
+		Connector(
+			'expcon', 1,
+			'-   -   -   B19 B12 B9  E6  D6  E7  D7  B11 B6  E9  D9  B8  C8  D8  E8  C7  C6 '
+			'-   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -  '
+		),  # X3
+		Connector(
+			'expcon', 2,
+			'A8  -   A12 A13 B13 C13 D13 E13 A14 C14 D14 E14 D11 C10 A9  B10 D12 E12 -   - '
+			'B15 -   C15 -   D15 -   E15 A16 B16 -   C16 D16 B17 -   C17 A17 B18 A7  A18 - '
+		), # X4
 	]
 
 	@property
 	def file_templates(self) -> dict[str, str]:
 		return {
 			**super().file_templates,
-			'{{name}}-openocd.cfg': r'''
+			'{{name}}-openocd.cfg': dedent(r'''
 			interface ftdi
 			{# FTDI descriptors is identical between non-5G and 5G recent Versa boards #}
 			ftdi_device_desc 'Lattice ECP5_5G VERSA Board'
@@ -173,7 +179,7 @@ class VersaECP5Platform(ECP5Platform):
 			{% else -%}
 			jtag newtap ecp5 tap -irlen 8 -expected-id 0x01112043 ; # LFE5UM-45F
 			{% endif %}
-			'''
+			''')
 		}
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:
@@ -183,8 +189,8 @@ class VersaECP5Platform(ECP5Platform):
 		openocd = environ.get('OPENOCD', 'openocd')
 		with products.extract(f'{name}-openocd.cfg', f'{name}.svf') as files:
 			(config_filename, vector_filename) = files
-			check_call([openocd,
-				'-f', config_filename,
+			check_call([
+				openocd, '-f', config_filename,
 				'-c', f'transport select jtag; init; svf -quiet {vector_filename}; exit'
 			])
 

--- a/torii_boards/lattice/ice40/blackice.py
+++ b/torii_boards/lattice/ice40/blackice.py
@@ -23,24 +23,22 @@ class BlackIcePlatform(ICE40Platform):
 		Resource(
 			'clk100', 0, Pins('129', dir = 'i'), Clock(100e6), Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = '71 67 68 70', attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		# Semantic aliases
 		Resource('led_b', 0, Pins('71', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, Pins('67', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_o', 0, Pins('68', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, Pins('70', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		*ButtonResources(pins = '63 64',       invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
+		*ButtonResources(pins = '63 64', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		*SwitchResources(pins = '37 38 39 41', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = '88', tx = '85',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS', PULLUP = 1),
 			role = 'dce'
 		),
-
-		SRAMResource(0,
+		SRAMResource(
+			0,
 			cs_n = '136', oe_n = '45', we_n = '120',
 			a = '137 138 139 141 142 42 43 44 73 74 75 76 115 116 117 118 119 78',
 			d = '135 134 130 128 125 124 122 121 61 60 56 55 52 49 48 47',
@@ -48,14 +46,14 @@ class BlackIcePlatform(ICE40Platform):
 		),
 	]
 	connectors  = [
-		Connector('pmod', 0, ' 94  91  88  85 - -  95  93  90  87 - -'),  # PMOD1/2
-		Connector('pmod', 1, '105 102  99  97 - - 104 101  98  96 - -'),  # PMOD3/4
+		Connector('pmod', 0, '94 91 88 85 - - 95 93 90 87 - -'),  # PMOD1/2
+		Connector('pmod', 1, '105 102 99 97 - - 104 101 98 96 - -'),  # PMOD3/4
 		Connector('pmod', 2, '143 114 112 107 - - 144 113 110 106 - -'),  # PMOD5/6
-		Connector('pmod', 3, ' 10   9   2   1 - -   8   7   4   3 - -'),  # PMOD7/8
-		Connector('pmod', 4, ' 20  19  16  15 - -  18  17  12  11 - -'),  # PMOD9/10
-		Connector('pmod', 5, ' 34  33  22  21 - -  32  31  26  25 - -'),  # PMOD11/12
-		Connector('pmod', 6, ' 29  28  24  23 - -'),  # PMOD13
-		Connector('pmod', 7, ' 71  67  68  70 - -'),  # PMOD14
+		Connector('pmod', 3, '10 9 2 1 - - 8 7 4 3 - -'),  # PMOD7/8
+		Connector('pmod', 4, '20 19 16 15 - - 18 17 12 11 - -'),  # PMOD9/10
+		Connector('pmod', 5, '34 33 22 21 - - 32 31 26 25 - -'),  # PMOD11/12
+		Connector('pmod', 6, '29 28 24 23 - -'),  # PMOD13
+		Connector('pmod', 7, '71 67 68 70 - -'),  # PMOD14
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/blackice_ii.py
+++ b/torii_boards/lattice/ice40/blackice_ii.py
@@ -20,27 +20,27 @@ class BlackIceIIPlatform(ICE40Platform):
 	description = 'myStorm BlackIce II Lattice iCE40-HX4k Development Board'
 
 	resources   = [
-		Resource('clk100', 0, Pins('129', dir = 'i'),
+		Resource(
+			'clk100', 0,
+			Pins('129', dir = 'i'),
 			Clock(100e6), Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = '71 67 68 70', attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		# Color aliases
 		Resource('led_b', 0, Pins('71', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, Pins('67', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_o', 0, Pins('68', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, Pins('70', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		*ButtonResources(pins = '63 64',       invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
+		*ButtonResources(pins = '63 64', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		*SwitchResources(pins = '37 38 39 41', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = '88', tx = '85', rts = '91', cts = '94',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS', PULLUP = 1),
 			role = 'dce'
 		),
-
-		SRAMResource(0,
+		SRAMResource(
+			0,
 			cs_n = '23', oe_n = '29', we_n = '120',
 			a = '137 138 139 141 142 42 43 44 73 74 75 76 115 116 117 118 119 78',
 			d = '136 135 134 130 125 124 122 121 62 61 60 56 55 48 47 45',
@@ -49,14 +49,14 @@ class BlackIceIIPlatform(ICE40Platform):
 		),
 	]
 	connectors  = [
-		Connector('pmod', 0, ' 94  91  88  85 - -  95  93  90  87 - -'),  # PMOD1/2
-		Connector('pmod', 1, '105 102  99  97 - - 104 101  98  96 - -'),  # PMOD3/4
+		Connector('pmod', 0, '94 91 88 85 - - 95 93 90  87 - -'),  # PMOD1/2
+		Connector('pmod', 1, '105 102 99 97 - - 104 101 98 96 - -'),  # PMOD3/4
 		Connector('pmod', 2, '143 114 112 107 - - 144 113 110 106 - -'),  # PMOD5/6
-		Connector('pmod', 3, ' 10   9   2   1 - -   8   7   4   3 - -'),  # PMOD7/8
-		Connector('pmod', 4, ' 20  19  16  15 - -  18  17  12  11 - -'),  # PMOD9/10
-		Connector('pmod', 5, ' 34  33  22  21 - -  32  31  26  25 - -'),  # PMOD11/12
-		Connector('pmod', 6, ' 37  38  39  41 - -'),  # PMOD13
-		Connector('pmod', 7, ' 71  67  68  70 - -'),  # PMOD14
+		Connector('pmod', 3, '10 9 2 1 - - 8 7 4 3 - -'),  # PMOD7/8
+		Connector('pmod', 4, '20 19 16 15 - - 18 17 12 11 - -'),  # PMOD9/10
+		Connector('pmod', 5, '34 33 22 21 - - 32 31 26 25 - -'),  # PMOD11/12
+		Connector('pmod', 6, '37 38 39 41 - -'),  # PMOD13
+		Connector('pmod', 7, '71 67 68 70 - -'),  # PMOD14
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/fomu_hacker.py
+++ b/torii_boards/lattice/ice40/fomu_hacker.py
@@ -19,21 +19,23 @@ class FomuHackerPlatform(ICE40Platform):
 
 	resources   = [
 		Resource(
-			'clk48', 0, Pins('F5', dir = 'i'), Clock(48e6),
+			'clk48', 0,
+			Pins('F5', dir = 'i'), Clock(48e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = 'A5', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'C5', g = 'B5', b = 'A5', invert = True,
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		DirectUSBResource(0, d_p = 'A4', d_n = 'A2', pullup = 'D5',
+		DirectUSBResource(
+			0,
+			d_p = 'A4', d_n = 'A2', pullup = 'D5',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS'),
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'C1', clk = 'D1', copi = 'F1', cipo = 'E1',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS'),
 		),

--- a/torii_boards/lattice/ice40/fomu_pvt.py
+++ b/torii_boards/lattice/ice40/fomu_pvt.py
@@ -22,24 +22,22 @@ class FomuPVTPlatform(ICE40Platform):
 			'clk48', 0, Pins('F4', dir = 'i'), Clock(48e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = 'A5', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'B5', g = 'A5', b = 'C5', invert = True,
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-
-		DirectUSBResource(0,
+		DirectUSBResource(
+			0,
 			d_p = 'A1', d_n = 'A2', pullup = 'A4',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'C1', clk = 'D1', copi = 'F1', cipo = 'E1',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS'),
 		),
-
 		Resource('touch', 0, Pins('E4')),
 		Resource('touch', 1, Pins('D5')),
 		Resource('touch', 2, Pins('E5')),

--- a/torii_boards/lattice/ice40/ice40_hx1k_blink_evn.py
+++ b/torii_boards/lattice/ice40/ice40_hx1k_blink_evn.py
@@ -22,23 +22,21 @@ class ICE40HX1KBlinkEVNPlatform(ICE40Platform):
 			'clk3p3', 0, Pins('13', dir = 'i'), Clock(3.3e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = '59 56 53 51', attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
 		Resource('touch', 0, Pins('60'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('touch', 1, Pins('57'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('touch', 2, Pins('54'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('touch', 3, Pins('52'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '49', clk = '48', copi = '45', cipo = '46',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors  = [
-		Connector('pmod',  1, '10  9  8  7 - -  4  3  2  1 - -'), # J1
-		Connector('pmod',  5, '40 42 62 64 - - 37 41 63 45 - -'), # J5
-		Connector('pmod',  6, '25 24 21 20 - - 26 27 28 33 - -'), # J6
+		Connector('pmod', 1, '10 9 8 7 - - 4 3 2 1 - -'), # J1
+		Connector('pmod', 5, '40 42 62 64 - - 37 41 63 45 - -'), # J5
+		Connector('pmod', 6, '25 24 21 20 - - 26 27 28 33 - -'), # J6
 		Connector('pmod', 11, '49 45 46 48 - -'), # J11
 		Connector('pmod', 12, '59 56 53 51 - -'), # J12
 	]

--- a/torii_boards/lattice/ice40/ice40_hx8k_b_evn.py
+++ b/torii_boards/lattice/ice40/ice40_hx8k_b_evn.py
@@ -19,47 +19,55 @@ class ICE40HX8KBEVNPlatform(ICE40Platform):
 
 	resources   = [
 		Resource(
-			'clk12', 0, Pins('J3', dir = 'i'), Clock(12e6),
+			'clk12', 0,
+			Pins('J3', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(
 			pins = 'C3 B3 C4 C5 A1 A2 B4 B5',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		), # D2..D9
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'B10', tx = 'B12', rts = 'B13', cts = 'A15', dtr = 'A16', dsr = 'B14', dcd = 'B15',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS', PULLUP = 1),
 			role = 'dce'
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'R12', clk = 'R11', copi = 'P12', cipo = 'P11',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors  = [
-		Connector('j', 1, # J1
+		Connector(
+			'j', 1, # J1
 			'A16 -   A15 B15 B13 B14 -   -   B12 B11 '
 			'A11 B10 A10 C9  -   -   A9  B9  B8  A7  '
 			'B7  C7  -   -   A6  C6  B6  C5  A5  C4  '
-			'-   -   B5  C3  B4  B3  A2  A1  -   -   '),
-		Connector('j', 2, # J2
+			'-   -   B5  C3  B4  B3  A2  A1  -   -   '
+		),
+		Connector(
+			'j', 2, # J2
 			'-   -   -   R15 P16 P15 -   -   N16 M15 '
 			'M16 L16 K15 K16 -   -   K14 J14 G14 F14 '
 			'J15 H14 -   -   H16 G15 G16 F15 F16 E14 '
-			'-   -   E16 D15 D16 D14 C16 B16 -   -   '),
-		Connector('j', 3, # J3
+			'-   -   E16 D15 D16 D14 C16 B16 -   -   '
+		),
+		Connector(
+			'j', 3, # J3
 			'R16 -   T15 T16 T13 T14 -   -   N12 P13 '
 			'N10 M11 T11 P10 -   -   T10 R10 P8  P9  '
 			'T9  R9  -   -   T7  T8  T6  R6  T5  R5  '
-			'-   -   R3  R4  R2  T3  T1  T2  -   -   '),
-		Connector('j', 4, # J4
+			'-   -   R3  R4  R2  T3  T1  T2  -   -   '
+		),
+		Connector(
+			'j', 4, # J4
 			'-   -   -   R1  P1  P2  -   -   N3  N2  '
 			'M2  M1  L3  L1  -   -   K3  K1  J2  J1  '
 			'H2  J3  -   -   G2  H1  F2  G1  E2  F1  '
-			'-   -   D1  D2  C1  C2  B1  B2  -   -   '),
+			'-   -   D1  D2  C1  C2  B1  B2  -   -   '
+		),
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/ice40_up5k_b_evn.py
+++ b/torii_boards/lattice/ice40/ice40_up5k_b_evn.py
@@ -23,7 +23,6 @@ class ICE40UP5KBEVNPlatform(ICE40Platform):
 			'clk12', 0, Pins('35', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		# 3 LEDs are present in an RGB common-anode package.
 		*LEDResources(
 			pins = '39 40 41', invert = True,
@@ -32,7 +31,6 @@ class ICE40UP5KBEVNPlatform(ICE40Platform):
 		Resource('led_b', 0, PinsN('39', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, PinsN('40', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, PinsN('41', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
 		# 4 DIP switches are available, requiring internal pull-ups.
 		# The switches' 'ON' label points to the position which
 		# connects them to ground, so invert the inputs.
@@ -40,26 +38,31 @@ class ICE40UP5KBEVNPlatform(ICE40Platform):
 			pins = '23 25 34 43', invert = True,
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS', PULLUP = 1)
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', copi = '14', cipo = '17',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors  = [
-		Connector('aardvark', 0, # J1
+		Connector(
+			'aardvark', 0, # J1
 			'- - - - 14 - 15 17 16 -'
 		),
-		Connector('pmod', 0, # U6 (board), U11 (schematic)
+		Connector(
+			'pmod', 0, # U6 (board), U11 (schematic)
 			'16 14 17 15 - - 27 26 32 31 - -'
 		),
-		Connector('j', 0, # 'Header A' (J52)
+		Connector(
+			'j', 0, # 'Header A' (J52)
 			'- - 39 14 40 17 - 15 41 16 - -'
 		),
-		Connector('j', 1, # 'Header B' (J2)
+		Connector(
+			'j', 1, # 'Header B' (J2)
 			'- - 23 - 25 - 26 36 27 42 32 38 31 28 37 15 34 - 43 -'
 		),
-		Connector('j', 2, # 'Header C' (J3)
+		Connector(
+			'j', 2, # 'Header C' (J3)
 			'- 12 3 21 3 13 48 20 45 19 47 18 44 11 46 10 2 9 - 6'
 		),
 	]

--- a/torii_boards/lattice/ice40/icebreaker.py
+++ b/torii_boards/lattice/ice40/icebreaker.py
@@ -22,26 +22,24 @@ class ICEBreakerPlatform(ICE40Platform):
 			'clk12', 0, Pins('35', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = '11 37', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		# Semantic aliases
 		Resource('led_r', 0, PinsN('11', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, PinsN('37', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
 		*ButtonResources(pins = '10', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = '6', tx = '9',
 			attrs = Attrs(IO_STANDARD = 'SB_LVTTL', PULLUP = 1)
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', copi = '14', cipo = '17', wp_n = '12', hold_n = '13',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors = [
-		Connector('pmod', 0, ' 4  2 47 45 - -  3 48 46 44 - -'), # PMOD1A
+		Connector('pmod', 0, '4 2 47 45 - -  3 48 46 44 - -'), # PMOD1A
 		Connector('pmod', 1, '43 38 34 31 - - 42 36 32 28 - -'), # PMOD1B
 		Connector('pmod', 2, '27 25 21 19 - - 26 23 20 18 - -'), # PMOD2
 	]
@@ -71,7 +69,6 @@ class ICEBreakerPlatform(ICE40Platform):
 		Resource(
 			'led_g', 4, Pins('3', dir = 'o', conn = ('pmod', 2)), Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*ButtonResources(
 			pins = {
 				1: '9', 2: '4', 3: '10'

--- a/torii_boards/lattice/ice40/icebreaker_bitsy.py
+++ b/torii_boards/lattice/ice40/icebreaker_bitsy.py
@@ -24,39 +24,37 @@ class ICEBreakerBitsyPlatform(ICE40Platform):
 			'clk12', 0, Pins('35', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		DirectUSBResource(0,
+		DirectUSBResource(
+			0,
 			d_p = '42', d_n = '38', pullup = '37',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', copi = '14', cipo = '17', wp_n = '18', hold_n = '19',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = '39', g = '40', b = '41', invert = True,
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 		*LEDResources(pins = '25 6', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, PinsN('25', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, PinsN('6', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
 		*ButtonResources(pins = '2', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
 	]
 	connectors = [
-		Connector('edge', 0,  # Pins bottom P0 - P12,
-			{
-				'0' : '47', '1' : '44', '2' : '48', '3' : '45', '4' :  '4', '5' :  '3',
-				'6' :  '9', '7' : '10', '8' : '11', '9' : '12', '10': '21', '11': '13',
+		Connector('edge', 0, { # Pins bottom P0 - P12,
+				'0': '47', '1': '44', '2': '48', '3': '45', '4': '4', '5': '3',
+				'6': '9', '7': '10', '8': '11', '9': '12', '10': '21', '11': '13',
 				'12': '20', '13': '25', '14': '23', '15': '27', '16': '26', '17': '28',
 				'18': '31', '19': '32', '20': '34', '21': '36', '22': '43', '23': '46'
 			}
 		),
-		Connector('pmod', 1, ' 0  2  4  6 - -  1  3  5  7 - -', conn = ('edge', '0')), # PMOD 1
+		Connector('pmod', 1, '0 2 4 6 - - 1 3 5 7 - -', conn = ('edge', '0')), # PMOD 1
 		Connector('pmod', 2, '22 19 16 17 - - 21 18 15 20 - -', conn = ('edge', '0')), # PMOD 2
-		Connector('pmod', 3, '14  9 11  8 - - 13 10 12 23 - -', conn = ('edge', '0'))  # PMOD 3
+		Connector('pmod', 3, '14 9 11 8 - - 13 10 12 23 - -', conn = ('edge', '0'))  # PMOD 3
 	]
 
 	def toolchain_program(

--- a/torii_boards/lattice/ice40/icestick.py
+++ b/torii_boards/lattice/ice40/icestick.py
@@ -22,30 +22,28 @@ class ICEStickPlatform(ICE40Platform):
 			'clk12', 0, Pins('21', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = '99 98 97 96 95', attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = '9', tx = '8', rts = '7', cts = '4', dtr = '3', dsr = '2', dcd = '1',
 			attrs = Attrs(IO_STANDARD = 'SB_LVTTL', PULLUP = 1),
 			role = 'dce'
 		),
-
-		IrDAResource(0,
+		IrDAResource(
+			0,
 			rx = '106', tx = '105', sd = '107',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '71', clk = '70', copi = '67', cipo = '68',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors  = [
-		Connector('pmod', 0, '78 79 80 81 - - 87 88 90 91 - -'),  # J2
-
+		Connector('pmod', 0, '78 79 80 81 - - 87 88 90 91 - -'), # J2
 		Connector('j', 1, '- - 112 113 114 115 116 117 118 119'), # J1
-		Connector('j', 3, '- -  62  61  60  56  48  47  45  44'), # J3
+		Connector('j', 3, '- - 62 61 60 56 48 47 45 44'), # J3
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/icesugar.py
+++ b/torii_boards/lattice/ice40/icesugar.py
@@ -22,42 +22,40 @@ class ICESugarPlatform(ICE40Platform):
 			'clk12', 0, Pins('35', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(pins = '40 41 39', invert = True, attrs = Attrs(IO_STANDARD = 'LVCMOS33')),
-
 		# Semantic aliases
 		Resource('led_r', 0, PinsN('40', dir = 'o'), Attrs(IO_STANDARD = 'LVCMOS33')),
 		Resource('led_g', 0, PinsN('41', dir = 'o'), Attrs(IO_STANDARD = 'LVCMOS33')),
 		Resource('led_b', 0, PinsN('39', dir = 'o'), Attrs(IO_STANDARD = 'LVCMOS33')),
-
 		*SwitchResources(
 			pins = '18 19 20 21',
 			attrs = Attrs(IO_STANDARD = 'LVCMOS33')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = '4', tx = '6',
 			attrs = Attrs(IO_STANDARD = 'LVTTL33', PULLUP = 1)
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', copi = '14', cipo = '17', wp_n = '12', hold_n = '13',
 			attrs = Attrs(IO_STANDARD = 'LVCMOS33')
 		),
-
-		Resource('usb', 0,
-			Subsignal('d_p',    Pins('10', dir = 'io')),
-			Subsignal('d_n',    Pins('9', dir = 'io')),
+		# TODO(aki): Replace with DirectUSBResource
+		Resource(
+			'usb', 0,
+			Subsignal('d_p', Pins('10', dir = 'io')),
+			Subsignal('d_n', Pins('9', dir = 'io')),
 			Subsignal('pullup', Pins('11', dir = 'o')),
 			Attrs(IO_STANDARD = 'LVCMOS33')
 		),
 	]
 
 	connectors = [
-		Connector('pmod', 0, '10  6  3 48 - -  9  4  2 47 - -'), # PMOD1 - IO pins shared by USB
+		Connector('pmod', 0, '10 6 3 48 - -  9 4 2 47 - -'), # PMOD1 - IO pins shared by USB
 		Connector('pmod', 1, '46 44 42 37 - - 45 43 38 36 - -'), # PMOD2
 		Connector('pmod', 2, '34 31 27 25 - - 32 28 26 23 - -'), # PMOD3
-		Connector('pmod', 3, '21 20 19 18 - -  -  -  -  - - -'), # PMOD4 - IO pins used for switches via jumpers
+		Connector('pmod', 3, '21 20 19 18 - - - - - - - -'), # PMOD4 - IO pins used for switches via jumpers
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/icesugar_nano.py
+++ b/torii_boards/lattice/ice40/icesugar_nano.py
@@ -22,24 +22,23 @@ class ICESugarNanoPlatform(ICE40Platform):
 			'clk12', 0, Pins('D1', dir = 'i'), Clock(12e6),
 			Attrs(GLOBAL = True, IO_STANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(pins = 'B6', invert = False, attrs = Attrs(IO_STANDARD = 'LVCMOS33')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			tx = 'B3', rx = 'A3',
 			attrs = Attrs(IO_STANDARD = 'LVTTL33', PULLUP = 1)
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'D5', clk = 'E5', copi = 'E4', cipo = 'F5',
 			attrs = Attrs(IO_STANDARD = 'LVCMOS33')
 		),
 	]
 
 	connectors = [
-		Connector('pmod', 0, 'E2 D1 B1 A1 - -'),                    # PMOD1
-		Connector('pmod', 1, 'B3 A3 B6 C5 - -'),                    # PMOD2
-		Connector('pmod', 2, 'B4 B5 E1 B1 - - C6 E3 C2 A1 - -'),    # PMOD3
+		Connector('pmod', 0, 'E2 D1 B1 A1 - -'), # PMOD1
+		Connector('pmod', 1, 'B3 A3 B6 C5 - -'), # PMOD2
+		Connector('pmod', 2, 'B4 B5 E1 B1 - - C6 E3 C2 A1 - -'), # PMOD3
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/nandland_go.py
+++ b/torii_boards/lattice/ice40/nandland_go.py
@@ -23,24 +23,22 @@ class NandlandGoPlatform(ICE40Platform):
 		Resource(
 			'clk25', 0, Pins('15', dir = 'i'), Clock(25e6)
 		),
-
 		*LEDResources(pins = '56 57 59 60'),
 		*ButtonResources(pins = '53 51 54 52'),
-
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = '3', b = '4', c = '93', d = '91', e = '90', f = '1', g = '2',
 			invert = True
 		),
-		Display7SegResource(1,
+		Display7SegResource(
+			1,
 			a = '100', b = '99', c = '97', d = '95', e = '94', f = '8', g = '96',
 			invert = True
 		),
-
 		UARTResource(0, rx = '73', tx = '74'),
-
 		*SPIFlashResources(0, cs_n = '49', clk = '48', copi = '45', cipo = '46'),
-
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = '36 37 40',
 			g = '29 30 33',
 			b = '28 41 42',

--- a/torii_boards/lattice/ice40/tinyfpga_bx.py
+++ b/torii_boards/lattice/ice40/tinyfpga_bx.py
@@ -21,29 +21,30 @@ class TinyFPGABXPlatform(ICE40Platform):
 		Resource(
 			'clk16', 0, Pins('B2', dir = 'i'), Clock(16e6), Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
 		*LEDResources(pins = 'B3', attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		DirectUSBResource(0, d_p = 'B4', d_n = 'A4', pullup = 'A3',
+		DirectUSBResource(
+			0,
+			d_p = 'B4', d_n = 'A4', pullup = 'A3',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'F7', clk = 'G7', copi = 'G6', cipo = 'H7', wp_n = 'H4', hold_n = 'J8',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
 	]
 	connectors  = [
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			# Left side of the board
-			#     1  2  3  4  5  6  7  8  9 10 11 12 13
-			'   A2 A1 B1 C2 C1 D2 D1 E2 E1 G2 H1 J1 H2 '
+			# 1  2  3  4  5  6  7  8  9  10 11 12 13
+			' A2 A1 B1 C2 C1 D2 D1 E2 E1 G2 H1 J1 H2 '
 			# Right side of the board
-			#          14 15 16 17 18 19 20 21 22 23 24
-			'         H9 D9 D8 C9 A9 B8 A8 B7 A7 B6 A6 '
+			# 14 15 16 17 18 19 20 21 22 23 24
+			' H9 D9 D8 C9 A9 B8 A8 B7 A7 B6 A6 '
 			# Bottom of the board
 			# 25 26 27 28 29 30 31
-			'G1 J3 J4 G9 J9 E8 J2'
+			' G1 J3 J4 G9 J9 E8 J2'
 		),
 	]
 

--- a/torii_boards/lattice/ice40/upduino_v1.py
+++ b/torii_boards/lattice/ice40/upduino_v1.py
@@ -24,8 +24,8 @@ class UpduinoV1Platform(ICE40Platform):
 		Resource('led_g', 0, PinsN('39', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_b', 0, PinsN('40', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, PinsN('41', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', cipo = '17', copi = '14',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),

--- a/torii_boards/lattice/ice40/upduino_v3.py
+++ b/torii_boards/lattice/ice40/upduino_v3.py
@@ -26,13 +26,14 @@ class UpduinoV3Platform(ICE40Platform):
 		Resource(
 			'clk12', 0, Pins('20', dir = 'i'), Clock(12e6), Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = '41', g = '39', b = '40', invert = True,
-			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')),
-
+			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
+		),
 		# To use QSPI mode, solder the appropriate jumpers.
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = '16', clk = '15', cipo = '17', copi = '14', wp_n = '10', hold_n = '20',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),

--- a/torii_boards/lattice/machxo2/tinyfpga_ax1.py
+++ b/torii_boards/lattice/machxo2/tinyfpga_ax1.py
@@ -16,7 +16,8 @@ class TinyFPGAAX1Platform(MachXO2Platform):
 	description = 'TinyFPGA AX1 Lattice MachXO2-256 Development Board'
 
 	connectors  = [
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			# Left side of the board
 			#  1  2  3  4  5  6  7  8  9 10 11
 			'13 14 16 17 20 21 23 25 26 27 28 '

--- a/torii_boards/lattice/machxo2/tinyfpga_ax2.py
+++ b/torii_boards/lattice/machxo2/tinyfpga_ax2.py
@@ -16,7 +16,8 @@ class TinyFPGAAX2Platform(MachXO2Platform):
 	description = 'TinyFPGA AX2 Lattice MachXO2-1200 Development Board'
 
 	connectors  = [
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			# Left side of the board
 			#  1  2  3  4  5  6  7  8  9 10 11
 			'13 14 16 17 20 21 23 25 26 27 28 '

--- a/torii_boards/lattice/machxo3/machxo3_sk.py
+++ b/torii_boards/lattice/machxo3/machxo3_sk.py
@@ -25,48 +25,51 @@ class MachXO3SKPlatform(MachXO3LPlatform):
 			'clk12', 0, Pins('C8', dir = 'i'),
 			Clock(12e6), Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
-		UARTResource(0,
+		# need to solder R14-R18, R20-R22
+		UARTResource(
+			0,
 			rx = 'A11', tx = 'C11', rts = 'F10', cts = 'D11', dtr = 'B11', dsr = 'A12', dcd = 'B13', ri = 'A14',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33'), role = 'dce'
-		), # need to solder R14-R18, R20-R22
-
+		),
 		*LEDResources(
 			pins = 'H11 J13 J11 L12 K11 L13 N15 P16',
 			invert = True, attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		), # D9..D2
-
 		*ButtonResources(pins = 'B3', invert = True, attrs = Attrs(IO_TYPE = 'LVCMOS33')),
-
-		*SwitchResources(pins = 'N2 P1 M3 N1',
+		*SwitchResources(
+			pins = 'N2 P1 M3 N1',
 			invert = True, attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		), # SW2
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'R5', clk = 'P6', copi = 'T13', cipo = 'T6',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
 	]
 	connectors  = [
-		Connector('j', 3, # J3
+		Connector(
+			'j', 3, # J3
 			'-  -  A13 C13 F8  B12 C12 E11 E10 D10 '
 			'-  -  F9  C10 E8  E9  E7  D8  D7  C7  '
 			'-  -  C5  D6  E6  C4  A10 F7  D9  B9  '
 			'-  -  B6  B7  B5  A5  B4  A4  -   A3  '
 		),
-		Connector('j', 4, # J4
+		Connector(
+			'j', 4, # J4
 			'-  -  K12 K13 M14 N14 L14 N16 M15 M16 '
 			'-  -  L15 L16 K14 K16 K15 J14 H14 J15 '
 			'-  -  J16 H15 H16 G15 G16 F15 F16 E15 '
 			'-  -  E16 E14 D16 C15 D14 F14 G14 B16 '
 		),
-		Connector('j', 6, # J6
+		Connector(
+			'j', 6, # J6
 			'-  -  T12 T14 R11 R13 T11 M11 P11 N10 '
 			'-  -  T10 P10 R9  R10 T9  N9  P9  M8  '
 			'-  -  T8  L8  P8  M6  R7  R8  P7  T7  '
 			'-  -  L7  R6  N6  T5  R4  P4  T3  T4  '
 		),
-		Connector('j', 8, # J8
+		Connector(
+			'j', 8, # J8
 			'-  -  H6  N3  M2  M1  L2  L1  L3  L5  '
 			'-  -  K4  J1  K1  J2  J3  H3  H2  H1  '
 			'-  -  G2  G1  F2  F1  E2  E1  D2  D1  '

--- a/torii_boards/quicklogic/eos_s3/quickfeather.py
+++ b/torii_boards/quicklogic/eos_s3/quickfeather.py
@@ -23,42 +23,30 @@ class QuickfeatherPlatform(QuicklogicPlatform):
 	pretty_name = 'QuickFeather'
 	description = 'QuickLogic EOS S3 Development Board'
 
+	resources   = [
+		*ButtonResources(pins = '62'),
+		RGBLEDResource(0, r = '34', g = '39', b = '38'),
+		UARTResource(0, rx = '9', tx = '8'),
+		SPIResource(0, cs_n = '11', clk = '20', copi = '16', cipo = '17'),
+		SPIResource(
+			1,
+			cs_n = '37', clk = '40', copi = '36', cipo = '42',
+			role = 'peripheral'
+		),
+		I2CResource(0, scl = '4', sda = '5'),
+		I2CResource(1, scl = '22', sda = '21'),
+		DirectUSBResource(0, d_p = '10', d_n = '14'),
+		Resource(
+			'swd', 0,
+			Subsignal('clk', Pins('54', dir = 'io')),
+			Subsignal('io',  Pins('53', dir = 'io')),
+		),
+	]
+
 	connectors = [
 		Connector('J', 2, '- 28 22 21 37 36 42 40 7 2 4 5'),
 		Connector('J', 3, '- 8 9 17 16 20 6 55 31 25 47 - - - - 41'),
 		Connector('J', 8, '27 26 33 32 23 57 56 3 64 62 63 61 59 - - -'),
-	]
-
-	resources   = [
-		*ButtonResources(pins = '62'),
-
-		RGBLEDResource(0, r = '34', g = '39', b = '38'),
-
-		UARTResource(0,
-			rx = '9', tx = '8',
-		),
-
-		SPIResource(0,
-			cs_n = '11', clk = '20', copi = '16', cipo = '17'
-		),
-		SPIResource(1,
-			cs_n = '37', clk = '40', copi = '36', cipo = '42',
-			role = 'peripheral'
-		),
-
-		I2CResource(0,
-			scl = '4', sda = '5'
-		),
-		I2CResource(1,
-			scl = '22', sda = '21'
-		),
-
-		DirectUSBResource(0, d_p = '10', d_n = '14'),
-
-		Resource('swd', 0,
-			Subsignal('clk', Pins('54', dir = 'io')),
-			Subsignal('io',  Pins('53', dir = 'io')),
-		),
 	]
 
 	# This programmer requires OpenOCD with support for eos-s3:

--- a/torii_boards/test/blinky.py
+++ b/torii_boards/test/blinky.py
@@ -39,7 +39,7 @@ class Blinky(Elaboratable):
 			inverts[index] ^= switch
 
 		clk_freq = platform.default_clk_frequency
-		timer = Signal(range(int(clk_freq//2)), reset = int(clk_freq//2) - 1)
+		timer = Signal(range(int(clk_freq // 2)), reset = int(clk_freq // 2) - 1)
 		flops = Signal(len(leds))
 
 		m.d.comb += Cat(leds).eq(flops ^ Cat(inverts))

--- a/torii_boards/xilinx/artix7/alchitry_au.py
+++ b/torii_boards/xilinx/artix7/alchitry_au.py
@@ -38,20 +38,20 @@ class AlchitryAuPlatform(XilinxPlatform):
 			'clk100', 0, Pins('N14', dir = 'i'), Clock(10e7),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		# On-Board LED Array
 		*LEDResources(
 			pins = 'K13 K12 L14 L13 M16 M14 M12 N16',
-			attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		Resource('usb', 0,
+			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
+		),
+		Resource(
+			'usb', 0,
 			Subsignal('usb_tx', Pins('P16', dir = 'o')),
 			Subsignal('usb_rx', Pins('P15', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		# TODO: This is untested
-		DDR3Resource(0,
+		DDR3Resource(
+			0,
 			rst_n = 'D13',
 			clk_p = 'G14', clk_n = 'F14', clk_en = 'D15',
 			cs_n = 'D16', we_n = 'E11', ras_n = 'D14', cas_n = 'D14',
@@ -65,25 +65,29 @@ class AlchitryAuPlatform(XilinxPlatform):
 	]
 
 	connectors  = [
-		Connector('bank', 0,
+		Connector(
+			'bank', 0,
 			'T8  T7  T5  R5  R8  P8  L2  L3  J1  K1  H1  H2  G1  G2  K5  E6 '
 			'T10 T9  R6  R7  P9  N9  K2  K3  J4  J5  H3  J3  H4  H5  N6  M6 '
 		),
-		Connector('bank', 1,
+		Connector(
+			'bank', 1,
 			'D1  E2  A2  B2  E1  F2  F3  F4  A3  B4  A4  A5  B5  B6  A7  B7 '
 			'B1  C1  C2  C3  D3  E3  C4  D4  G4  G5  E5  F5  D5  D6  C6  C7 '
 		),
-		Connector('bank', 2,
+		Connector(
+			'bank', 2,
 			'T13 R13 T12 R12 R11 R10 N2  N3  P3  P4  M4  L4  N4  M5  L5  P5 '
 			'P11 P10 N12 N11 P13 N13 M1  M2  P1  N1  R1  R2  T2  R3  T3  T4 '
 		),
-		Connector('bank', 3,
+		Connector(
+			'bank', 3,
 			'L14 L13 M12 N16 R16 R15 P14 M15 P16 P15  -   -   -   -   -   - '
 			'K13 K12 M16 M14 T16 T14 N14   -   -   -  -   -   -   -   -   - '
 		)
 	]
 
-	def toolchain_program(self, products: BuildProducts , name: str) -> None:
+	def toolchain_program(self, products: BuildProducts, name: str) -> None:
 		from subprocess import check_call
 
 		(loader, bridge_bin) = find_loader()

--- a/torii_boards/xilinx/artix7/arty_a7.py
+++ b/torii_boards/xilinx/artix7/arty_a7.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
+
 from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run              import BuildPlan, BuildProducts
 from torii.hdl.ir                 import Fragment
@@ -24,94 +26,91 @@ class _ArtyA7Platform(XilinxPlatform):
 			'clk100', 0, Pins('E3', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 		Resource('rst', 0, PinsN('C2', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*LEDResources(pins = 'H5 J5 T9 T10', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		RGBLEDResource(0, r = 'G6', g = 'F6', b = 'E1', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		RGBLEDResource(1, r = 'G3', g = 'J4', b = 'G4', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		RGBLEDResource(2, r = 'J3', g = 'J2', b = 'H4', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		RGBLEDResource(3, r = 'K1', g = 'H6', b = 'K2', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*ButtonResources(pins = 'D9  C9  B9  B8 ', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		*SwitchResources(pins = 'A8  C11 C10 A10', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'A9', tx = 'D10',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		SPIResource(0,
+		SPIResource(
+			0,
 			cs_n = 'C1', clk = 'F1', copi = 'H1', cipo = 'G1',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('i2c', 0,
-			Subsignal('scl',        Pins('L18', dir = 'io')),
-			Subsignal('sda',        Pins('M18', dir = 'io')),
+		Resource(
+			'i2c', 0,
+			Subsignal('scl',  Pins('L18', dir = 'io')),
+			Subsignal('sda', Pins('M18', dir = 'io')),
 			Subsignal('scl_pullup', Pins('A14', dir = 'o')),
 			Subsignal('sda_pullup', Pins('A13', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'L13', clk = 'L16', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',    PinsN('K6', dir = 'o')),
-			Subsignal('clk',    DiffPairs('U9', 'V9', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL135')),
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('K6', dir = 'o')),
+			Subsignal('clk', DiffPairs('U9', 'V9', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL135')),
 			Subsignal('clk_en', Pins('N5', dir = 'o')),
-			Subsignal('cs',     PinsN('U8', dir = 'o')),
-			Subsignal('we',     PinsN('P5', dir = 'o')),
-			Subsignal('ras',    PinsN('P3', dir = 'o')),
-			Subsignal('cas',    PinsN('M4', dir = 'o')),
-			Subsignal('a',      Pins('R2 M6 N4 T1 N6 R7 V6 U7 R8 V7 R6 U6 T6 T8', dir = 'o')),
-			Subsignal('ba',     Pins('R1 P4 P2', dir = 'o')),
-			Subsignal('dqs',    DiffPairs('N2 U2', 'N1 V2', dir = 'io'),
-								Attrs(IOSTANDARD = 'DIFF_SSTL135')
+			Subsignal('cs', PinsN('U8', dir = 'o')),
+			Subsignal('we', PinsN('P5', dir = 'o')),
+			Subsignal('ras', PinsN('P3', dir = 'o')),
+			Subsignal('cas', PinsN('M4', dir = 'o')),
+			Subsignal('a', Pins('R2 M6 N4 T1 N6 R7 V6 U7 R8 V7 R6 U6 T6 T8', dir = 'o')),
+			Subsignal('ba', Pins('R1 P4 P2', dir = 'o')),
+			Subsignal('dqs', DiffPairs('N2 U2', 'N1 V2', dir = 'io'), Attrs(IOSTANDARD = 'DIFF_SSTL135')),
+			Subsignal(
+				'dq',
+				Pins('K5 L3 K3 L6 M3 M1 L4 M2 V4 T5 U4 V5 V1 T3 U3 R3', dir = 'io'),
+				Attrs(IN_TERM = 'UNTUNED_SPLIT_40')
 			),
-			Subsignal('dq',     Pins('K5 L3 K3 L6 M3 M1 L4 M2 V4 T5 U4 V5 V1 T3 U3 R3', dir = 'io'),
-								Attrs(IN_TERM = 'UNTUNED_SPLIT_40')
-			),
-			Subsignal('dm',     Pins('L1 U1', dir = 'o')),
-			Subsignal('odt',    Pins('R5', dir = 'o')),
+			Subsignal('dm', Pins('L1 U1', dir = 'o')),
+			Subsignal('odt', Pins('R5', dir = 'o')),
 			Attrs(IOSTANDARD = 'SSTL135', SLEW = 'FAST'),
 		),
-
 		Resource(
-			'eth_clk25', 0, Pins('G18', dir = 'o'), Clock(25e6),
-			Attrs(IOSTANDARD = 'LVCMOS33')
+			'eth_clk25', 0,
+			Pins('G18', dir = 'o'), Clock(25e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 		Resource(
-			'eth_clk50', 0, Pins('G18', dir = 'o'), Clock(50e6),
-			Attrs(IOSTANDARD = 'LVCMOS33')
+			'eth_clk50', 0, Pins('G18', dir = 'o'), Clock(50e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('eth_mii', 0,
-			Subsignal('rst',     PinsN('C16', dir = 'o')),
-			Subsignal('mdio',    Pins('K13', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')),
-			Subsignal('tx_clk',  Pins('H16', dir = 'i')),
-			Subsignal('tx_en',   Pins('H15', dir = 'o')),
+		Resource(
+			'eth_mii', 0,
+			Subsignal('rst', PinsN('C16', dir = 'o')),
+			Subsignal('mdio', Pins('K13', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')),
+			Subsignal('tx_clk', Pins('H16', dir = 'i')),
+			Subsignal('tx_en', Pins('H15', dir = 'o')),
 			Subsignal('tx_data', Pins('H14 J14 J13 H17', dir = 'o')),
-			Subsignal('rx_clk',  Pins('F15', dir = 'i')),
-			Subsignal('rx_dv',   Pins('G16', dir = 'i'), Attrs(PULLDOWN = 'TRUE')), # strap to select MII
-			Subsignal('rx_er',   Pins('C17', dir = 'i')),
+			Subsignal('rx_clk', Pins('F15', dir = 'i')),
+			Subsignal('rx_dv', Pins('G16', dir = 'i'), Attrs(PULLDOWN = 'TRUE')), # strap to select MII
+			Subsignal('rx_er', Pins('C17', dir = 'i')),
 			Subsignal('rx_data', Pins('D18 E17 E18 G17', dir = 'i')),
-			Subsignal('col',     Pins('D17', dir = 'i')),
-			Subsignal('crs',     Pins('G14', dir = 'i')),
+			Subsignal('col', Pins('D17', dir = 'i')),
+			Subsignal('crs', Pins('G14', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('eth_rmii', 0,
-			Subsignal('rst',       PinsN('C16', dir = 'o')),
-			Subsignal('mdio',      Pins('K13', dir = 'io')),
-			Subsignal('mdc',       Pins('F16', dir = 'o')),
-			Subsignal('tx_en',     Pins('H15', dir = 'o')),
-			Subsignal('tx_data',   Pins('H14 J14', dir = 'o')),
+		Resource(
+			'eth_rmii', 0,
+			Subsignal('rst', PinsN('C16', dir = 'o')),
+			Subsignal('mdio', Pins('K13', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')),
+			Subsignal('tx_en', Pins('H15', dir = 'o')),
+			Subsignal('tx_data', Pins('H14 J14', dir = 'o')),
 			Subsignal('rx_crs_dv', Pins('G14', dir = 'i')),
-			Subsignal('rx_dv',     Pins('G16', dir = 'i'), Attrs(PULLUP = 'TRUE')), # strap to select RMII
-			Subsignal('rx_er',     Pins('C17', dir = 'i')),
-			Subsignal('rx_data',   Pins('D18 E17', dir = 'i')),
+			Subsignal('rx_dv', Pins('G16', dir = 'i'), Attrs(PULLUP = 'TRUE')), # strap to select RMII
+			Subsignal('rx_er', Pins('C17', dir = 'i')),
+			Subsignal('rx_data', Pins('D18 E17', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		)
 	]
@@ -119,25 +118,23 @@ class _ArtyA7Platform(XilinxPlatform):
 		Connector('pmod', 0, 'G13 B11 A11 D12 - - D13 B18 A18 K16 - -'), # JA
 		Connector('pmod', 1, 'E15 E16 D15 C15 - - J17 J18 K15 J15 - -'), # JB
 		Connector('pmod', 2, 'U12 V12 V10 V11 - - U14 V14 T13 U13 - -'), # JC
-		Connector('pmod', 3, ' D4  D3  F4  F3 - -  E2  D2  H2  G2 - -'), # JD
-
+		Connector('pmod', 3, 'D4 D3 F4 F3 - -  E2 D2 H2 G2 - -'), # JD
 		Connector('ck_io', 0, {
 			# Outer Digital Header
-			'io0':  'V15',
-			'io1':  'U16',
-			'io2':  'P14',
-			'io3':  'T11',
-			'io4':  'R12',
-			'io5':  'T14',
-			'io6':  'T15',
-			'io7':  'T16',
-			'io8':  'N15',
-			'io9':  'M16',
+			'io0': 'V15',
+			'io1': 'U16',
+			'io2': 'P14',
+			'io3': 'T11',
+			'io4': 'R12',
+			'io5': 'T14',
+			'io6': 'T15',
+			'io7': 'T16',
+			'io8': 'N15',
+			'io9': 'M16',
 			'io10': 'V17',
 			'io11': 'U18',
 			'io12': 'R17',
 			'io13': 'P17',
-
 			# Inner Digital Header
 			'io26': 'U11',
 			'io27': 'V16',
@@ -155,7 +152,6 @@ class _ArtyA7Platform(XilinxPlatform):
 			'io39': 'R18',
 			'io40': 'P18',
 			'io41': 'N17',
-
 			# Outer Analog Header as Digital IO
 			'a0': 'F5',
 			'a1': 'D8',
@@ -163,7 +159,6 @@ class _ArtyA7Platform(XilinxPlatform):
 			'a3': 'E7',
 			'a4': 'D7',
 			'a5': 'D5',
-
 			# Inner Analog Header as Digital IO
 			'io20': 'B7',
 			'io21': 'B6',
@@ -174,19 +169,18 @@ class _ArtyA7Platform(XilinxPlatform):
 		}),
 		Connector('xadc', 0, {
 			# Outer Analog Header
-			'vaux4_n':   'C5',
-			'vaux4_p':   'C6',
-			'vaux5_n':   'A5',
-			'vaux5_p':   'A6',
-			'vaux6_n':   'B4',
-			'vaux6_p':   'C4',
-			'vaux7_n':   'A1',
-			'vaux7_p':   'B1',
-			'vaux15_n':  'B2',
-			'vaux15_p':  'B3',
-			'vaux0_n':  'C14',
-			'vaux0_p':  'D14',
-
+			'vaux4_n': 'C5',
+			'vaux4_p': 'C6',
+			'vaux5_n': 'A5',
+			'vaux5_p': 'A6',
+			'vaux6_n': 'B4',
+			'vaux6_p': 'C4',
+			'vaux7_n': 'A1',
+			'vaux7_p': 'B1',
+			'vaux15_n': 'B2',
+			'vaux15_p': 'B3',
+			'vaux0_n': 'C14',
+			'vaux0_p': 'D14',
 			# Inner Analog Header
 			'vaux12_n': 'B7',
 			'vaux12_p': 'B6',
@@ -194,14 +188,13 @@ class _ArtyA7Platform(XilinxPlatform):
 			'vaux13_p': 'E5',
 			'vaux14_n': 'A4',
 			'vaux14_p': 'A3',
-
 			# Power Measurements
-			'vsnsuv_n':   'B17',
-			'vsnsuv_p':   'B16',
-			'vsns5v0_n':  'B12',
-			'vsns5v0_p':  'C12',
-			'isns5v0_n':  'F14',
-			'isns5v0_p':  'F13',
+			'vsnsuv_n': 'B17',
+			'vsnsuv_p': 'B16',
+			'vsns5v0_n': 'B12',
+			'vsns5v0_p': 'C12',
+			'isns5v0_n': 'F14',
+			'isns5v0_p': 'F13',
 			'isns0v95_n': 'A16',
 			'isns0v95_p': 'A15',
 		})
@@ -209,17 +202,15 @@ class _ArtyA7Platform(XilinxPlatform):
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:
 		overrides = {
-			'script_before_bitstream':
-				'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
-			'script_after_bitstream':
-				'write_cfgmem -force -format bin -interface spix4 -size 16 '
-				'-loadbit \'up 0x0 {name}.bit\' -file {name}.bin'.format(name = name),
-			'add_constraints':
-				'''
+			'script_before_bitstream': 'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
+			'script_after_bitstream': dedent(f'''
+				write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit 'up 0x0 {name}.bit' -file {name}.bin
+			'''),
+			'add_constraints': dedent('''
 				set_property INTERNAL_VREF 0.675 [get_iobanks 34]
 				set_property CFGBVS VCCO [current_design]
 				set_property CONFIG_VOLTAGE 3.3 [current_design]
-				'''
+			''')
 		}
 		return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 

--- a/torii_boards/xilinx/artix7/cmod_a7.py
+++ b/torii_boards/xilinx/artix7/cmod_a7.py
@@ -30,49 +30,44 @@ class _CmodA7Platform(XilinxPlatform):
 		Resource(
 			'clk12', 0, Pins('L17', dir = 'i'), Clock(12e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(pins = 'A17 C16', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'C17', g = 'B16', b = 'B17', invert = True,
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*ButtonResources(pins = 'A18 B18', attrs = Attrs(IOSTANDARD='LVCMOS33')),
-
 		UARTResource(0, rx = 'J17', tx = 'J18', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'K19', clk = 'E19', copi = 'D19', cipo = 'D18', wp_n = 'G18',
 			hold_n = 'F18',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		SRAMResource(0,
+		SRAMResource(
+			0,
 			cs_n = 'N19', oe_n = 'P19', we_n = 'R19',
 			a = 'M18 M19 K17 N17 P17 P18 R18 W19 U19 V19 W18 T17 T18 U17 U18 V16 W16 W17 V15',
 			d = 'W15 W13 W14 U15 U16 V13 V14 U14'
 		),
-
 		# One-wire interface to crypto authentication device
 		# May not be populated on the board
 		Resource('atsha204a', 0, Pins('D17', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33'))
 	]
 	connectors  = [
 		Connector('pmod', 0, 'G17 G19 N18 L18 - - H17 H19 J19 K18 - -'), # JA
-
 		# Pin 24/25 are VCC and GND
 		# Pin 15/16 are analog (XADC)
-		Connector('gpio', 0,
-			'M3  L3 A16  K3 C15  H1 A15 B15 A14  J3  J1  K2 '
-			'L1  L2   -   -  M1  N3  P3  M2  N1  N2  P1   - '
-			' -  R3  T3  R2  T1  T2  U1  W2  V2  W3  V3  W5 '
-			'V4  U4  V5  W4  U5  U2  W6  U3  U7  W7  U8  V8 '
+		Connector(
+			'gpio', 0,
+			'M3  L3 A16 K3  C15 H1  A15 B15 A14 J3  J1  K2 '
+			'L1  L2 -   -   M1  N3  P3  M2  N1  N2  P1   - '
+			'-   R3 T3  R2  T1  T2  U1  W2  V2  W3  V3  W5 '
+			'V4  U4 V5  W4  U5  U2  W6  U3  U7  W7  U8  V8 '
 		),
-
 		Connector('xadc', 0, {
-			'vaux4_n':  'G2',
-			'vaux4_p':  'G3',
+			'vaux4_n': 'G2',
+			'vaux4_p': 'G3',
 			'vaux12_n': 'J2',
 			'vaux12_p': 'H',
 		})

--- a/torii_boards/xilinx/artix7/mega65.py
+++ b/torii_boards/xilinx/artix7/mega65.py
@@ -19,47 +19,37 @@ class Mega65r3Platform(XilinxPlatform):
 
 	resources = [
 		Resource('clk100', 0, Pins('V13', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*LEDResources(pins = 'U22', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		Resource('iec', 0,
+		Resource(
+			'iec', 0,
 			Subsignal('rst', Pins('AB21', dir = 'o')),
 			Subsignal('atn', Pins('N17', dir = 'o')),
-
 			Subsignal('data_en', Pins('Y21', dir = 'o')),
 			Subsignal('data_o', Pins('Y22', dir = 'o')),
 			Subsignal('data_i', Pins('AB22', dir = 'i'), Attrs(PULLUP = 'TRUE')),
-
 			Subsignal('clk_en', Pins('AA21', dir = 'o')),
 			Subsignal('clk_o', Pins('Y19', dir = 'o')),
 			Subsignal('clk_i', Pins('Y18', dir = 'i'), Attrs(PULLUP = 'TRUE')),
-
 			Subsignal('srq_en', Pins('AB20', dir = 'o')),
 			Subsignal('srq_o', Pins('U20', dir = 'o')),
 			Subsignal('srq_i', Pins('AA18', dir = 'i')),
-
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('cart', 0,
+		Resource(
+			'cart', 0,
 			Subsignal('ctrl_en', Pins('G18', dir = 'o')),
 			Subsignal('ctrl_dir', Pins('U17', dir = 'o')),
-
 			Subsignal('addr_en', Pins('L19', dir = 'o')),
 			Subsignal('addr_dir_lo', Pins('L21', dir = 'o')),
 			Subsignal('addr_dir_hi', Pins('L18', dir = 'o')),
-
 			Subsignal('data_en', Pins('U21', dir = 'o')),
 			Subsignal('data_dir', Pins('V22', dir = 'o')),
-
 			Subsignal('phi2', Pins('V17', dir = 'o')),
 			Subsignal('dotclk', Pins('AA19', dir = 'o')),
 			Subsignal('rst', Pins('N14', dir = 'o')),
-
 			Subsignal('nmi', Pins('W17', dir = 'i')),
 			Subsignal('irq', Pins('P14', dir = 'i')),
 			Subsignal('dma', Pins('P15', dir = 'i')),
-
 			Subsignal('exrom', Pins('R19', dir = 'io')),
 			Subsignal('ba', Pins('N13', dir = 'io')),
 			Subsignal('rw', Pins('R18', dir = 'io')),
@@ -68,23 +58,19 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('io1', Pins('N15', dir = 'io')),
 			Subsignal('game', Pins('W22', dir = 'io')),
 			Subsignal('io2', Pins('AA20', dir = 'io')),
-
 			Subsignal('data', Pins('P16 R17 P20 R16 U18 V18 W20 W21', dir = 'io')),
-
 			Subsignal('addr', Pins(
 				'K19 K18 K21 M22 L20 J20 J21 K22 '
 				'H17 H20 G20 J15 H19 M20 N22 H18',
 				dir = 'io'
 			)),
-
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('keyboard', 0,
+		Resource(
+			'keyboard', 0,
 			Subsignal('clk', Pins('A14', dir = 'o')),
 			Subsignal('out', Pins('A13', dir = 'o')),
 			Subsignal('in', Pins('C13', dir = 'i')),
-
 			Subsignal('tck', Pins('E13', dir = 'o')),
 			Subsignal('tdo', Pins('E14', dir = 'o')),
 			Subsignal('tdi', Pins('D15', dir = 'i')),
@@ -92,14 +78,14 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('jtag_en', Pins('B13', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('paddle', 0,
+		Resource(
+			'paddle', 0,
 			Subsignal('in', Pins('H13 G15 J14 J22', dir = 'i')),
 			Subsignal('drain', Pins('H22', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('joystick', 0,
+		Resource(
+			'joystick', 0,
 			Subsignal('up', Pins('C14', dir = 'i')),
 			Subsignal('down', Pins('F16', dir = 'i')),
 			Subsignal('left', Pins('F14', dir = 'i')),
@@ -107,8 +93,8 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('fire', Pins('E17', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('joystick', 1,
+		Resource(
+			'joystick', 1,
 			Subsignal('up', Pins('W19', dir = 'i')),
 			Subsignal('down', Pins('P17', dir = 'i')),
 			Subsignal('left', Pins('F21', dir = 'i')),
@@ -116,12 +102,12 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('fire', Pins('F15', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		VGADACResource(0,
+		VGADACResource(
+			0,
 			clk = 'AA9',
-			r = 'U15 V15 T14  Y17  Y16  AB17 AA16 AB16',
-			g = 'Y14 W14 AA15 AB15 Y13  AA14 AA13 AB13',
-			b = 'W10 Y12 AB12 AA11 AB11 Y11  AB10 AA10',
+			r = 'U15 V15 T14 Y17 Y16 AB17 AA16 AB16',
+			g = 'Y14 W14 AA15 AB15 Y13 AA14 AA13 AB13',
+			b = 'W10 Y12 AB12 AA11 AB11 Y11 AB10 AA10',
 			hs = 'W12', vs = 'V14',
 			extras = [
 				Subsignal('sync', PinsN('V10', dir = 'o')),
@@ -129,8 +115,8 @@ class Mega65r3Platform(XilinxPlatform):
 			],
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('hdmi', 0,
+		Resource(
+			'hdmi', 0,
 			Subsignal('clk', DiffPairs('W1', 'Y1', dir = 'o')),
 			Subsignal('data', DiffPairs('AA1 AB3 AA5', 'AB1 AB2 AB5', dir = 'o')),
 			Subsignal('scl', Pins('AB7', dir = 'io')),
@@ -141,13 +127,11 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('cec', Pins('W9', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
 		I2CResource(0, scl = 'A15', sda = 'A16', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		# Seeed Grove
 		I2CResource('grove', 0, scl = 'G21', sda = 'G22', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		Resource('audio', 0,
+		Resource(
+			'audio', 0,
 			Subsignal('left', Pins('L6', dir = 'o')),
 			Subsignal('right', Pins('F4', dir = 'o')),
 			Subsignal('sd', Pins('F18', dir = 'o')),
@@ -157,13 +141,13 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('sync', Pins('F19', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('spi_flash', 0,
+		Resource(
+			'spi_flash', 0,
 			Subsignal('data', Pins('P22 R22 P21 R21', dir = 'io'), Attrs(PULLUP = 'TRUE')),
 			Subsignal('cs', PinsN('T19', dir = 'o')),
 		),
-
-		Resource('hyper_ram', 0,
+		Resource(
+			'hyper_ram', 0,
 			Subsignal('clk', Pins('D22', dir = 'o'), Attrs(SLEW = 'FAST', DRIVE = '16')),
 			Subsignal('data', Pins('A21 D21 C20 A20 B20 A19 E21 E22', dir = 'io'), Attrs(SLEW = 'FAST', DRIVE = '16')),
 			Subsignal('rwds', Pins('B21', dir = 'io'), Attrs(SLEW = 'FAST', DRIVE = '16')),
@@ -171,8 +155,8 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('cs', Pins('C22', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'FALSE'),
 		),
-
-		Resource('ethernet', 0,
+		Resource(
+			'ethernet', 0,
 			Subsignal('led', Pins('R14', dir = 'o')),
 			Subsignal('clk', Pins('L4', dir = 'o'), Attrs(SLEW = 'FAST')),
 			Subsignal('rst', Pins('K6', dir = 'o')),
@@ -185,29 +169,28 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('rxdv', Pins('K4', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
 		UARTResource(0, rx = 'L14', tx = 'L13', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		Resource('max10', 0,
+		Resource(
+			'max10', 0,
 			Subsignal('tx', Pins('M13', dir = 'i')),
 			Subsignal('rx', Pins('K16', dir = 'o')),
 			Subsignal('rst', Pins('L16', dir = 'io')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'B17', cmd = 'B16', cd = 'D17', wp_n = 'C17',
 			dat0 = 'B18', dat1 = 'C18', dat2 = 'C19', dat3 = 'B15',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		*SDCardResources(1,
+		*SDCardResources(
+			1,
 			clk = 'G2', cmd = 'J2', cd = 'K1', wp_n = None,
 			dat0 = 'H2', dat1 = 'H3', dat2 = 'J1', dat3 = 'K2',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
-
-		Resource('floppy', 0,
+		Resource(
+			'floppy', 0,
 			Subsignal('density', Pins('P6', dir = 'o')),
 			Subsignal('motor', Pins('M5 H15', dir = 'o')),
 			Subsignal('select', Pins('N5 G17', dir = 'o')),

--- a/torii_boards/xilinx/artix7/nexys4ddr.py
+++ b/torii_boards/xilinx/artix7/nexys4ddr.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
+
 from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run              import BuildPlan, BuildProducts
 from torii.hdl.ir                 import Fragment
@@ -26,12 +28,11 @@ class Nexys4DDRPlatform(XilinxPlatform):
 	resources   = [
 		Resource('clk100', 0, Pins('E3', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')),
 		Resource('rst', 0, PinsN('C12', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*SwitchResources(
 			pins = {
-				0 : 'J15', 1 : 'L16', 2 : 'M13', 3 : 'R15', 4 : 'R17',
-				5 : 'T18', 6 : 'U18', 7 : 'R13', 10: 'R16', 11: 'T13',
-				12: 'H6',  13: 'U12', 14: 'U11', 15: 'V10'
+				0: 'J15', 1: 'L16', 2: 'M13', 3: 'R15', 4: 'R17',
+				5: 'T18', 6: 'U18', 7: 'R13', 10: 'R16', 11: 'T13',
+				12: 'H6', 13: 'U12', 14: 'U11', 15: 'V10'
 			},
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
@@ -39,155 +40,152 @@ class Nexys4DDRPlatform(XilinxPlatform):
 			pins = {8: 'T8', 9: 'U8'},
 			attrs = Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-
 		*LEDResources(
 			pins = 'H17 K15 J13 N14 R18 V17 U17 U16 V16 T15 U14 T16 V15 V14 V12 V11',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'N15', g = 'M16', b = 'R12',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		RGBLEDResource(1,
+		RGBLEDResource(
+			1,
 			r = 'N16', g = 'R11', b = 'G14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'T10', b = 'R10', c = 'K16', d = 'K13', e = 'P15',
 			f = 'T11', g = 'L18', dp = 'H15', invert = True,
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('display_7seg_an', 0,
+		Resource(
+			'display_7seg_an', 0,
 			PinsN('J17 J18 T9 J14 P14 T14 K2 U13', dir = 'o'),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		Resource('button_reset', 0, PinsN('C12', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-		Resource('button_center', 0, Pins('N17',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-		Resource('button_up', 0, Pins('M18',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-		Resource('button_left', 0, Pins('P17',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-		Resource('button_right', 0, Pins('M17',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-		Resource('button_down', 0, Pins('P18',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		VGAResource(0,
+		Resource('button_center', 0, Pins('N17', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		Resource('button_up', 0, Pins('M18', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		Resource('button_left', 0, Pins('P17', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		Resource('button_right', 0, Pins('M17', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		Resource('button_down', 0, Pins('P18', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		VGAResource(
+			0,
 			r = 'A3 B4 C5 A4',
 			g = 'C6 A5 B6 A6',
 			b = 'B7 C7 D7 D8',
 			hs = 'B11', vs = 'B12',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'B1',  cmd = 'C1',  cd = 'A1',
 			dat0 = 'C2', dat1 = 'E1', dat2 = 'F1', dat3 = 'D2',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('sd_card_reset', 0,
-			Pins('E2', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')
-		),
-
-		Resource('accelerometer', 0,                        # ADXL362
-			Subsignal('cs',   PinsN('D15',    dir = 'o')),
-			Subsignal('clk',  Pins('F15',     dir = 'o')),
-			Subsignal('copi', Pins('F14',     dir = 'o')),
-			Subsignal('cipo', Pins('E15',     dir = 'i')),
-			Subsignal('int',  Pins('B13 C16', dir = 'i'),
-				Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'TRUE')
-			),
+		Resource('sd_card_reset', 0, Pins('E2', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),
+		Resource(
+			'accelerometer', 0,                        # ADXL362
+			Subsignal('cs', PinsN('D15', dir = 'o')),
+			Subsignal('clk', Pins('F15', dir = 'o')),
+			Subsignal('copi', Pins('F14', dir = 'o')),
+			Subsignal('cipo', Pins('E15', dir = 'i')),
+			Subsignal('int', Pins('B13 C16', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'TRUE')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('temp_sensor', 0,                          # ADT7420
+		Resource(
+			'temp_sensor', 0, # ADT7420
 			Subsignal('scl', Pins('C14', dir = 'o')),
 			Subsignal('sda', Pins('C15', dir = 'io')),
 			Subsignal('int', Pins('D13', dir = 'i'), Attrs(PULLUP = 'TRUE')),
-			Subsignal('ct',  Pins('B14', dir = 'i'), Attrs(PULLUP = 'TRUE')),
+			Subsignal('ct', Pins('B14', dir = 'i'), Attrs(PULLUP = 'TRUE')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 
-		Resource('microphone', 0,                           # ADMP421
-			Subsignal('clk',    Pins('J5', dir = 'o')),
-			Subsignal('data',   Pins('H5', dir = 'i')),
+		Resource(
+			'microphone', 0, # ADMP421
+			Subsignal('clk', Pins('J5', dir = 'o')),
+			Subsignal('data', Pins('H5', dir = 'i')),
 			Subsignal('lr_sel', Pins('F5', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('audio', 0,
-			Subsignal('pwm', Pins('A11',  dir = 'o')),
-			Subsignal('sd',  PinsN('D12', dir = 'o')),
+		Resource(
+			'audio', 0,
+			Subsignal('pwm', Pins('A11', dir = 'o')),
+			Subsignal('sd', PinsN('D12', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'C4', tx = 'D4', rts = 'E5', cts = 'D3',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33'),
 			role = 'dce'
 		),
-
-		PS2Resource(0,
+		PS2Resource(
+			0,
 			clk = 'F4', dat = 'B2',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'TRUE')
 		),
-
-		Resource('eth', 0,                                  # LAN8720A
-			Subsignal('mdio',   Pins('A9',      dir = 'io')),
-			Subsignal('mdc',    Pins('C9',      dir = 'o')),
-			Subsignal('reset',  Pins('B3',      dir = 'o')),
-			Subsignal('rxd',    Pins('C11 D10', dir = 'io')),
-			Subsignal('rxerr',  Pins('C10',     dir = 'io')),
-			Subsignal('txd',    Pins('A10 A8',  dir = 'o')),
-			Subsignal('txen',   Pins('B9',      dir = 'o')),
-			Subsignal('crs_dv', Pins('D9',      dir = 'io')),
-			Subsignal('int',    PinsN('B8',     dir = 'io')),
-			Subsignal('clk',    Pins('D5',      dir = 'o'), Clock(50e6)),
+		Resource(
+			'eth', 0,  # LAN8720A
+			Subsignal('mdio', Pins('A9', dir = 'io')),
+			Subsignal('mdc', Pins('C9', dir = 'o')),
+			Subsignal('reset', Pins('B3', dir = 'o')),
+			Subsignal('rxd', Pins('C11 D10', dir = 'io')),
+			Subsignal('rxerr', Pins('C10', dir = 'io')),
+			Subsignal('txd', Pins('A10 A8', dir = 'o')),
+			Subsignal('txen', Pins('B9', dir = 'o')),
+			Subsignal('crs_dv', Pins('D9', dir = 'io')),
+			Subsignal('int', PinsN('B8', dir = 'io')),
+			Subsignal('clk', Pins('D5', dir = 'o'), Clock(50e6)),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'L13', clk = 'E9', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('ddr2', 0,                                 # MT47H64M16HR-25:H
+		Resource(
+			'ddr2', 0, # MT47H64M16HR-25:H
 			Subsignal('a', Pins('M4 P4 M6 T1 L3 P5 M2 N1 L4 N5 R2 K5 N6 K3', dir = 'o')),
-			Subsignal('dq',
+			Subsignal(
+				'dq',
 				Pins('R7 V6 R8 U7 V7 R6 U6 R5 T5 U3 V5 U4 V4 T4 V1 T3', dir = 'io'),
 				Attrs(IN_TERM = 'UNTUNED_SPLIT_50')
 			),
-			Subsignal('ba',  Pins('P2 P3 R1', dir = 'o')),
+			Subsignal('ba', Pins('P2 P3 R1', dir = 'o')),
 			Subsignal('clk', DiffPairs('L6', 'L5', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL18_I')),
 			Subsignal('clk_en', Pins('M1', dir = 'o')),
-			Subsignal('cs',  PinsN('K6', dir = 'o')),
-			Subsignal('we',  PinsN('N2', dir = 'o')),
+			Subsignal('cs', PinsN('K6', dir = 'o')),
+			Subsignal('we', PinsN('N2', dir = 'o')),
 			Subsignal('ras', PinsN('N4', dir = 'o')),
 			Subsignal('cas', PinsN('L1', dir = 'o')),
 			Subsignal('dqs', DiffPairs('U9 U2', 'V9 V2', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL18_I')),
-			Subsignal('dm',  Pins('T6 U1', dir = 'o')),
-			Subsignal('odt', Pins('R5',    dir = 'o')),
+			Subsignal('dm', Pins('T6 U1', dir = 'o')),
+			Subsignal('odt', Pins('R5', dir = 'o')),
 			Attrs(IOSTANDARD = 'SSTL18_I', SLEW = 'FAST'))
 	]
+
 	connectors = [
 		Connector('pmod', 0, 'C17 D18 E18 G17 - - D17 E17 F18 G18 - -'),  # JA
 		Connector('pmod', 1, 'D14 F16 G16 H14 - - E16 F13 G13 H16 - -'),  # JB
-		Connector('pmod', 2, 'K1  F6  J2  G6  - - E7  J3  J4  E6  - -'),  # JC
-		Connector('pmod', 3, 'H4  H1  G1  G3  - - H2  G4  G2  F3  - -')   # JD
+		Connector('pmod', 2, 'K1 F6 J2 G6 - - E7 J3 J4 E6 - -'),  # JC
+		Connector('pmod', 3, 'H4 H1 G1 G3 - - H2 G4 G2 F3 - -')   # JD
 	]
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:
 		overrides = {
-			'script_before_bitstream':
-				'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
-			'script_after_bitstream':
-				'write_cfgmem -force -format bin -interface spix4 -size 16 '
-				f'-loadbit \'up 0x0 {name}.bit\' -file {name}.bin',
-			'add_constraints':
-				'''
+			'script_before_bitstream': 'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
+			'script_after_bitstream': dedent(f'''
+				write_cfgmem -force -format bin -interface spix4 -size 16 -loadbit 'up 0x0 {name}.bit' -file {name}.bin
+			'''),
+			'add_constraints': dedent('''
 				set_property INTERNAL_VREF 0.9 [get_iobanks 34]
 				set_property CFGBVS VCCO [current_design]
 				set_property CONFIG_VOLTAGE 3.3 [current_design]
-				'''
+			''')
 		}
 		return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 

--- a/torii_boards/xilinx/artix7/te0714_03_50_2I.py
+++ b/torii_boards/xilinx/artix7/te0714_03_50_2I.py
@@ -19,16 +19,16 @@ class TE0714_03_50_2IPlatform(XilinxPlatform):
 
 	resources   = [
 		Resource('clk25', 0, Pins('T14', dir = 'i'), Clock(25e6), Attrs(IOSTANDARD = 'LVCMOS18')),
-
 		*LEDResources(pins = 'K18', attrs = Attrs(IOSTANDARD = 'LVCMOS18')),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'L15', clk = 'E8', copi = 'K16', cipo = 'K17', wp_n = 'J15', hold_n = 'J16',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS18')
 		)
 	]
 	connectors = [
-		Connector('JM1', 0,
+		Connector(
+			'JM1', 0,
 			'G4  D6  '
 			'G3  D5  '
 			'-   -   '
@@ -80,7 +80,8 @@ class TE0714_03_50_2IPlatform(XilinxPlatform):
 			'-   -   '
 			'-   -   '
 		),
-		Connector('JM2', 0,
+		Connector(
+			'JM2', 0,
 			'A12 B9  '
 			'B12 A9  '
 			'A13 B10 '

--- a/torii_boards/xilinx/kintex7/genesys2.py
+++ b/torii_boards/xilinx/kintex7/genesys2.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
 from typing                       import Literal
 
 from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
@@ -67,24 +68,28 @@ class Genesys2Platform(XilinxPlatform):
 			pins = 'T28 V19 U30 U29 V20 V26 W24 W23',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('fan', 0,
+		Resource(
+			'fan', 0,
 			Subsignal('pwm', Pins('W19', dir = 'o')),
 			Subsignal('tach', Pins('V21', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'Y20', tx = 'Y23',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		I2CResource(0,
+		I2CResource(
+			0,
 			scl = 'AE30', sda = 'AF30',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('ddr3', 0,
+		Resource(
+			'ddr3', 0,
 			Subsignal('rst', PinsN('AG5', dir = 'o'), Attrs(IOSTANDARD = 'SSTL15')),
-			Subsignal('clk',
-				DiffPairs(p = 'AB9', n = 'AC9', dir = 'o'),
-				Attrs(IOSTANDARD = 'DIFF_SSTL15_DCI')
+			Subsignal(
+				'clk',
+				DiffPairs(p = 'AB9', n = 'AC9', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL15_DCI')
 			),
 			Subsignal('clk_en', Pins('AJ9', dir = 'o')),
 			Subsignal('cs', PinsN('AH12', dir = 'o')),
@@ -96,53 +101,60 @@ class Genesys2Platform(XilinxPlatform):
 				'Y10 Y11 AB8 AA8 AB12 AA12 AH9 AG9', dir = 'o')
 			),
 			Subsignal('ba', Pins('AE9 AB10 AC11', dir = 'o')),
-			Subsignal('dqs',
-				DiffPairs(
-					p   = 'AD2 AG4 AG2 AH7',
-					n   = 'AD1 AG3 AH1 AJ7',
-					dir = 'io'
-				),
+			Subsignal(
+				'dqs',
+				DiffPairs(p = 'AD2 AG4 AG2 AH7', n = 'AD1 AG3 AH1 AJ7', dir = 'io'),
 				Attrs(IOSTANDARD = 'DIFF_SSTL15_DCI', ODT = 'RTT_40')
 			),
-			Subsignal('dq', Pins(
-				'AD3 AC2 AC1 AC5 AC4 AD6 AE6 AC7 '
-				'AF2 AE1 AF1 AE4 AE3 AE5 AF5 AF6 '
-				'AJ4 AH6 AH5 AH2 AJ2 AJ1 AK1 AJ3 '
-				'AF7 AG7 AJ6 AK6 AJ8 AK8 AK5 AK4', dir = 'io'),
+			Subsignal(
+				'dq',
+				Pins(
+					'AD3 AC2 AC1 AC5 AC4 AD6 AE6 AC7 '
+					'AF2 AE1 AF1 AE4 AE3 AE5 AF5 AF6 '
+					'AJ4 AH6 AH5 AH2 AJ2 AJ1 AK1 AJ3 '
+					'AF7 AG7 AJ6 AK6 AJ8 AK8 AK5 AK4',
+					dir = 'io'
+				),
 				Attrs(ODT = 'RTT_40')
 			),
 			Subsignal('dm', Pins('AD4 AF3 AH4 AF8', dir = 'o')),
 			Subsignal('odt', Pins('AK9', dir = 'o')),
 			Attrs(IOSTANDARD = 'SSTL15_DCI', SLEW = 'FAST', OUTPUT_IMPEDANCE = 'RDRV_40_40')
 		),
-		Resource('audio_i2c', 0,  # ADAU1761 I2C
+		Resource(
+			'audio_i2c', 0,  # ADAU1761 I2C
 			Subsignal('scl', Pins('AE19', dir = 'io')),
 			Subsignal('sda', Pins('AF18', dir = 'io')),
 			Subsignal('adr', Pins('AD19 AG19', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('audio_i2s', 0,  # ADAU1761 ADC, I2S
+		Resource(
+			'audio_i2s', 0,  # ADAU1761 ADC, I2S
 			Subsignal('clk', Pins('AG18', dir = 'o')), # BCLK
 			Subsignal('sd_adc', Pins('AH19', dir = 'o')), # ADC_SDATA
 			Subsignal('sd_dac', Pins('AJ19', dir = 'i')),  # DAC_SDATA
 			Subsignal('ws', Pins('AJ18', dir = 'o')), # LRCLK
 			Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('audio_clk', 0,  # ADAU1761 MCLK
+		Resource(
+			'audio_clk', 0,  # ADAU1761 MCLK
 			Pins('AK19', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		SPIResource(0,  # OLED, SSD1306, 128 x 32
+		SPIResource(
+			0,  # OLED, SSD1306, 128 x 32
 			cs_n = 'dummy-cs0', clk = 'AF17', copi = 'Y15',
 			cipo = 'dummy-cipo0', reset = 'AB17',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('oled', 0,  # OLED, UG-2832HSWEG04
+		Resource(
+			'oled', 0,  # OLED, UG-2832HSWEG04
 			Subsignal('dc', Pins('AC17', dir = 'o')),
 			Subsignal('vdd_en', PinsN('AG17', dir = 'o')),
 			Subsignal('vbat_en', PinsN('AB22', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('hdmi', 0,  # HDMI TX, connector J4
+		Resource(
+			'hdmi', 0,  # HDMI TX, connector J4
 			Subsignal('scl', Pins('AF27', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Subsignal('sda', Pins('AF26', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Subsignal('clk', DiffPairs(p = 'AA20', n = 'AB20', dir = 'o')),
@@ -153,7 +165,8 @@ class Genesys2Platform(XilinxPlatform):
 			)),
 			Attrs(IOSTANDARD = 'TMDS_33')
 		),
-		Resource('hdmi', 1,  # HDMI RX, connector J5
+		Resource(
+			'hdmi', 1,  # HDMI RX, connector J5
 			Subsignal('scl', Pins('AJ28', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Subsignal('sda', Pins('AJ29', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Subsignal('clk', DiffPairs(p = 'AE28', n = 'AF28', dir = 'i')),
@@ -164,30 +177,35 @@ class Genesys2Platform(XilinxPlatform):
 			)),
 			Attrs(IOSTANDARD = 'TMDS_33')
 		),
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = 'AK25 AG25 AH25 AK24 AJ24',
 			g = 'AJ23 AJ22 AH22 AK21 AJ21 AK23',
 			b = 'AH20 AG20 AF21 AK20 AG22',
 			hs = 'AF20', vs = 'AG23', invert_sync = True,
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		*SDCardResources(0,
+		*SDCardResources(
+			0,
 			clk = 'R28', cmd = 'R29', dat0 = 'R26', dat1 = 'R30',
 			dat2 = 'P29', dat3 = 'T30', cd = 'P28',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('sd_card_rst', 0,
+		Resource(
+			'sd_card_rst', 0,
 			Pins('AE24', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		ULPIResource(0,
+		ULPIResource(
+			0,
 			data = 'AE14 AE15 AC15 AC16 AB15 AA15 AD14 AC14',
 			rst = 'AB14', clk = 'AD18', dir = 'Y16', stp = 'AA17', nxt = 'AA16',
 			clk_dir = 'i', rst_invert = True, attrs = Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('vusb_oc', 0,
-			PinsN('AF16', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')
+		Resource(
+			'vusb_oc', 0, PinsN('AF16', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')
 		),
-		Resource('eth_rgmii', 0,
+		Resource(
+			'eth_rgmii', 0,
 			Subsignal('rst', PinsN('AH24', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Subsignal('mdc', Pins('AF12', dir = 'o')),
 			Subsignal('mdio', Pins('AG12', dir = 'io')),
@@ -202,23 +220,28 @@ class Genesys2Platform(XilinxPlatform):
 	]
 
 	connectors = [
-		Connector('pmod', 0,  # JA
+		Connector(
+			'pmod', 0,  # JA
 			'U27 U28 T26 T27 - - '
 			'T22 T23 T20 T21 - - '
 		),
-		Connector('pmod', 1,  # JB
+		Connector(
+			'pmod', 1,  # JB
 			'V29 V30 V25 W26 - - '
 			'T25 U25 U22 U23 - - '
 		),
-		Connector('pmod', 2,  # JC
+		Connector(
+			'pmod', 2,  # JC
 			'AC26 AJ27 AH30 AK29 - - '
 			'AD26 AG30 AK30 AK28 - - '
 		),
-		Connector('pmod', 3,  # JD
+		Connector(
+			'pmod', 3,  # JD
 			'V27 Y30 V24 W22 - - '
 			'U24 Y26 V22 W21 - - '
 		),
-		Connector('pmod', 4,  # JXADC
+		Connector(
+			'pmod', 4,  # JXADC
 			'J23 K23 L22 L21 - - '
 			'J24 K24 L23 K21 - - '
 		),
@@ -373,14 +396,14 @@ class Genesys2Platform(XilinxPlatform):
 			'script_after_read': 'auto_detect_xpm',
 			'script_before_bitstream':
 			'set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]',
-			'add_constraints': '''
+			'add_constraints': dedent('''
 			set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]
 			set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
 			set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR YES [current_design]
 			set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]
 			set_property CFGBVS VCCO [current_design]
 			set_property CONFIG_VOLTAGE 3.3 [current_design]
-			'''
+			''')
 		}
 		return super().toolchain_prepare(
 			fragment, name, **overrides, **kwargs
@@ -390,7 +413,7 @@ class Genesys2Platform(XilinxPlatform):
 	def file_templates(self) -> dict[str, str]:
 		return {
 			**super().file_templates,
-			'{{name}}-openocd.cfg': r'''
+			'{{name}}-openocd.cfg': dedent(r'''
 			source [find interface/ftdi/digilent-hs1.cfg]
 			# fix channel
 			ftdi_channel 1
@@ -398,7 +421,7 @@ class Genesys2Platform(XilinxPlatform):
 			transport select jtag
 			source [find cpld/xilinx-xc7.cfg]
 			source [find cpld/jtagspi.cfg]
-			'''
+			''')
 		}
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/xilinx/kintex7/kc705.py
+++ b/torii_boards/xilinx/kintex7/kc705.py
@@ -22,13 +22,12 @@ class KC705Platform(XilinxPlatform):
 		Resource(
 			'clk156', 0, DiffPairs('K28', 'K29', dir = 'i'), Clock(156e6), Attrs(IOSTANDARD = 'LVDS_25')
 		),
-
 		*LEDResources(
 			pins = 'AB8 AA8 AC9 AB9 AE26 G19 E18 F16',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS15')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'M19', tx = 'K24',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
@@ -40,8 +39,8 @@ class KC705Platform(XilinxPlatform):
 
 		openocd = environ.get('OPENOCD', 'openocd')
 		with products.extract(f'{name}.bit') as bitstream_filename:
-			check_call([openocd,
-				'-c', f'source [find board/kc705.cfg]; init; pld load 0 {bitstream_filename}; exit'
+			check_call([
+				openocd, '-c', f'source [find board/kc705.cfg]; init; pld load 0 {bitstream_filename}; exit'
 			])
 
 

--- a/torii_boards/xilinx/kintex_us/kcu105.py
+++ b/torii_boards/xilinx/kintex_us/kcu105.py
@@ -22,7 +22,6 @@ class KCU105Platform(XilinxPlatform):
 		Resource(
 			'clk125', 0, DiffPairs('G10', 'F10', dir = 'i'), Clock(125e6), Attrs(IOSTANDARD = 'LVDS')
 		),
-
 		*LEDResources(
 			pins = 'AP8 H23 P20 P21 N22 M22 R23 P23',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS18')
@@ -35,8 +34,8 @@ class KCU105Platform(XilinxPlatform):
 
 		openocd = environ.get('OPENOCD', 'openocd')
 		with products.extract(f'{name}.bit') as bitstream_filename:
-			check_call([openocd,
-				'-c', f'source [find board/kcu105.cfg]; init; pld load 0 {bitstream_filename}; exit'
+			check_call([
+				openocd, '-c', f'source [find board/kcu105.cfg]; init; pld load 0 {bitstream_filename}; exit'
 			])
 
 

--- a/torii_boards/xilinx/spartan3/mercury.py
+++ b/torii_boards/xilinx/spartan3/mercury.py
@@ -40,30 +40,28 @@ class MercuryPlatform(XilinxPlatform):
 		Resource(
 			'clk50', 0, Pins('P43', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33'), Clock(50e6)
 		),
-
 		Resource('button', 0, Pins('P41', dir = 'i'), Attrs(IOSTANDARD = 'LVTTL')),
-
 		# The serial interface and flash memory have a shared SPI bus.
 		# FPGA is secondary.
-		SPIResource('spi_serial', 0,
+		SPIResource(
+			'spi_serial', 0,
 			role = 'peripheral',
 			cs_n = 'P39', clk = 'P53', copi = 'P46', cipo = 'P51',
 			attrs = Attrs(IOSTANDARD = 'LVTTL'),
 		),
-
 		# FPGA is primary.
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'P27', clk = 'P53', copi = 'P46', cipo = 'P51',
 			attrs = Attrs(IOSTANDARD = 'LVTTL')
 		),
-
 		# ADC over SPI- FPGA is primary.
-		SPIResource('spi_adc', 0,
+		SPIResource(
+			'spi_adc', 0,
 			role = 'controller',
 			cs_n = 'P12', clk = 'P9', copi = 'P10', cipo = 'P21',
 			attrs = Attrs(IOSTANDARD = 'LVTTL'),
 		),
-
 		# GPIO/SRAM Control
 		# 5V tolerant GPIO is shared w/ the SRAM (on 200k gate devices) using
 		# this pin. All GPIO except gpio:30 (and gpio:20, though see comment
@@ -76,13 +74,13 @@ class MercuryPlatform(XilinxPlatform):
 	# Perhaps define some connectors as having a specific purpose- i.e. a 5V GPIO
 	# bus with data, peripheral-select, and control signals?
 	connectors = [
-		Connector('gpio', 0, '''
-			P59 P60 P61 P62 P64 P57
-			P56 P52 P50 P49 P85 P84
-			P83 P78 P77 P65 P70 P71
-			P72 P73 P5  P4  P6  P98
-			P94 P93 P90 P89 P88 P86
-			'''
+		Connector(
+			'gpio', 0,
+			'P59 P60 P61 P62 P64 P57 '
+			'P56 P52 P50 P49 P85 P84 '
+			'P83 P78 P77 P65 P70 P71 '
+			'P72 P73 P5  P4  P6  P98 '
+			'P94 P93 P90 P89 P88 P86 '
 		),  # 5V I/O- LVTTL.
 		Connector('dio', 0, 'P20 P32 P33 P34 P35 P36 P37'),  # Fast 3.3V IO
 		# (Directly attached to FPGA)- LVCMOS33.
@@ -106,7 +104,8 @@ class MercuryPlatform(XilinxPlatform):
 	]
 
 	sram = [
-		SRAMResource(0,
+		SRAMResource(
+			0,
 			cs_n = 'P3', we_n = 'gpio_0:29',
 			# According to the schematic, A19/Pin 25 on the SRAM is wired to
 			# gpio-0:20. However, according to the SRAM's datasheet, pin 25 is
@@ -156,7 +155,8 @@ class MercuryPlatform(XilinxPlatform):
 	]
 
 	_vga = [
-		VGAResource(0,
+		VGAResource(
+			0,
 			r = 'dio_0:1 dio_0:2 dio_0:3',
 			g = 'dio_0:4 dio_0:5 dio_0:6',
 			b = 'dio_0:7 clkio_0:1',
@@ -170,25 +170,26 @@ class MercuryPlatform(XilinxPlatform):
 	]
 
 	_sevenseg = [
-		Display7SegResource(0,
+		Display7SegResource(
+			0,
 			a = 'gpio_0:13', b = 'gpio_0:14', c = 'gpio_0:15', d = 'gpio_0:16',
 			e = 'gpio_0:17', f = 'gpio_0:18', g = 'gpio_0:19', dp = 'gpio_0:20',
 			invert = True, attrs = Attrs(IOSTANDARD = 'LVTTL')
 		),
-		Resource('display_7seg_ctrl', 0,
+		Resource(
+			'display_7seg_ctrl', 0,
 			Subsignal('en', Pins('9 10 11 12', dir = 'o', conn = ('gpio', 0))),
 			Attrs(IOSTANDARD = 'LVTTL')
 		)
 	]
 
 	_ps2 = [
-		PS2Resource(0,
-			clk = '2', dat = '1', conn = ('led', 0), attrs = Attrs(IOSTANDARD = 'LVTTL')
-		),
+		PS2Resource(0, clk = '2', dat = '1', conn = ('led', 0), attrs = Attrs(IOSTANDARD = 'LVTTL')),
 	]
 
 	_audio = [
-		Resource('audio', 0,
+		Resource(
+			'audio', 0,
 			Subsignal('l', Pins('30', dir = 'o', conn = ('gpio', 0))),
 			Subsignal('r', Pins('29', dir = 'o', conn = ('gpio', 0))),
 			Attrs(IOSTANDARD = 'LVTTL')

--- a/torii_boards/xilinx/spartan6/atlys.py
+++ b/torii_boards/xilinx/spartan6/atlys.py
@@ -36,184 +36,188 @@ class AtlysPlatform(XilinxPlatform):
 	default_rst = 'rst'
 
 	resources   = [
-		Resource('rst',    0, PinsN('T15', dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # RESET
+		Resource('rst', 0, PinsN('T15', dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # RESET
 		Resource(
-			'clk100', 0, Pins('L15',  dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')
+			'clk100', 0, Pins('L15', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		), # GCLK
-
-		Resource('led',    0, Pins('U18',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD0
-		Resource('led',    1, Pins('M14',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD1
-		Resource('led',    2, Pins('N14',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD2
-		Resource('led',    3, Pins('L14',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD3
-		Resource('led',    4, Pins('M13',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD4
-		Resource('led',    5, Pins('D4',   dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD5
-		Resource('led',    6, Pins('P16',  dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),       # LD6
-		Resource('led',    7, Pins('N12',  dir = 'o'), Attrs(IOSTANDARD = bank2_iostandard)), # LD7
-
-		Resource('button', 0, Pins('N4',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # BTNU
-		Resource('button', 1, Pins('P4',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # BTNL
-		Resource('button', 2, Pins('P3',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # BTND
-		Resource('button', 3, Pins('F6',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # BTNR
-		Resource('button', 4, Pins('F5',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # BTNC
-
-		Resource('switch', 0, Pins('A10',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW0
-		Resource('switch', 1, Pins('D14',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW1
-		Resource('switch', 2, Pins('C14',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW2
-		Resource('switch', 3, Pins('P15',  dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW3
-		Resource('switch', 4, Pins('P12',  dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # SW4
-		Resource('switch', 5, Pins('R5',   dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # SW5
-		Resource('switch', 6, Pins('T5',   dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # SW6
-		Resource('switch', 7, Pins('E4',   dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),       # SW7
-
-		UARTResource(0, rx = 'A16', tx = 'B16', attrs = Attrs(IOSTANDARD = 'LVCMOS33')), # J17/UART
-
-		PS2Resource(0, # PS/2 keyboard interface converted from J13 'HOST' USB connector
+		Resource('led', 0, Pins('U18', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD0
+		Resource('led', 1, Pins('M14', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD1
+		Resource('led', 2, Pins('N14', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD2
+		Resource('led', 3, Pins('L14', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD3
+		Resource('led', 4, Pins('M13', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD4
+		Resource('led', 5, Pins('D4', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),           # LD5
+		Resource('led', 6, Pins('P16', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),          # LD6
+		Resource('led', 7, Pins('N12', dir = 'o'), Attrs(IOSTANDARD = bank2_iostandard)),    # LD7
+		Resource('button', 0, Pins('N4', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # BTNU
+		Resource('button', 1, Pins('P4', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # BTNL
+		Resource('button', 2, Pins('P3', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # BTND
+		Resource('button', 3, Pins('F6', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # BTNR
+		Resource('button', 4, Pins('F5', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # BTNC
+		Resource('switch', 0, Pins('A10', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW0
+		Resource('switch', 1, Pins('D14', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW1
+		Resource('switch', 2, Pins('C14', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW2
+		Resource('switch', 3, Pins('P15', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),       # SW3
+		Resource('switch', 4, Pins('P12', dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)), # SW4
+		Resource('switch', 5, Pins('R5', dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)),  # SW5
+		Resource('switch', 6, Pins('T5', dir = 'i'), Attrs(IOSTANDARD = bank2_iostandard)),  # SW6
+		Resource('switch', 7, Pins('E4', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')),        # SW7
+		UARTResource(0, rx = 'A16', tx = 'B16', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),     # J17/UART
+		PS2Resource(
+			0, # PS/2 keyboard interface converted from J13 'HOST' USB connector
 			clk = 'P17', dat = 'N15', attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		PS2Resource(1, # PS/2 mouse interface converted from J13 'HOST' USB connector
+		PS2Resource(
+			1, # PS/2 mouse interface converted from J13 'HOST' USB connector
 			clk = 'N18', dat = 'P18', attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'AE14', clk = 'AH18', copi = 'AF14', cipo = 'AF20', wp_n = 'AG21', hold_n = 'AG17',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS25', SLEW = 'FAST'),
 		),
-
-		Resource('ddr2', 0,
-			Subsignal('clk',    DiffPairs('G3', 'G1', dir = 'o'),
-								Attrs(IOSTANDARD = 'DIFF_SSTL18_II', IN_TERM = 'NONE')),
+		Resource(
+			'ddr2', 0,
+			Subsignal(
+				'clk', DiffPairs('G3', 'G1', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL18_II', IN_TERM = 'NONE')
+			),
 			Subsignal('clk_en', Pins('H7', dir = 'o')),
-			Subsignal('we',     PinsN('E3', dir = 'o')),
-			Subsignal('ras',    PinsN('L5', dir = 'o')),
-			Subsignal('cas',    PinsN('K5', dir = 'o')),
-			Subsignal('a',      Pins('J7 J6 H5 L7 F3 H4 H3 H6 D2 D1 F4 D3 G6', dir = 'o')),
-			Subsignal('ba',     Pins('F2 F1 E1', dir = 'o')),
-			Subsignal('dqs',    DiffPairs('P2 L4', 'P1 L3', dir = 'o'),
-								Attrs(IOSTANDARD = 'DIFF_SSTL18_II')),
-			Subsignal('dq',     Pins('L2 L1 K2 K1 H2 H1 J3 J1 M3 M1 N2 N1 T2 T1 U2 U1', dir = 'io')),
-			Subsignal('dm',     Pins('K4 K3', dir = 'o')),
-			Subsignal('odt',    Pins('K6', dir = 'o')),
+			Subsignal('we', PinsN('E3', dir = 'o')),
+			Subsignal('ras', PinsN('L5', dir = 'o')),
+			Subsignal('cas', PinsN('K5', dir = 'o')),
+			Subsignal('a', Pins('J7 J6 H5 L7 F3 H4 H3 H6 D2 D1 F4 D3 G6', dir = 'o')),
+			Subsignal('ba', Pins('F2 F1 E1', dir = 'o')),
+			Subsignal('dqs', DiffPairs('P2 L4', 'P1 L3', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL18_II')),
+			Subsignal('dq', Pins('L2 L1 K2 K1 H2 H1 J3 J1 M3 M1 N2 N1 T2 T1 U2 U1', dir = 'io')),
+			Subsignal('dm', Pins('K4 K3', dir = 'o')),
+			Subsignal('odt', Pins('K6', dir = 'o')),
 			Attrs(IOSTANDARD = 'SSTL18_II', SLEW = 'FAST'),
 		),
-
-		Resource('eth_gmii', 0,
-			Subsignal('rst',     PinsN('G13', dir = 'o')),
-			Subsignal('int',     PinsN('L16', dir = 'o')),
-			Subsignal('mdio',    Pins('N17', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')), # Max 8.3MHz
+		Resource(
+			'eth_gmii', 0,
+			Subsignal('rst', PinsN('G13', dir = 'o')),
+			Subsignal('int', PinsN('L16', dir = 'o')),
+			Subsignal('mdio', Pins('N17', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')), # Max 8.3MHz
 			Subsignal('gtx_clk', Pins('L12', dir = 'o')),
-			Subsignal('tx_clk',  Pins('K16', dir = 'i')),
-			Subsignal('tx_en',   Pins('H15', dir = 'o')),
-			Subsignal('tx_er',   Pins('G18', dir = 'o')),
+			Subsignal('tx_clk', Pins('K16', dir = 'i')),
+			Subsignal('tx_en', Pins('H15', dir = 'o')),
+			Subsignal('tx_er', Pins('G18', dir = 'o')),
 			Subsignal('tx_data', Pins('H16 H13 K14 K13 J13 G14 H12 K12', dir = 'o')),
-			Subsignal('rx_clk',  Pins('K15', dir = 'i')),
-			Subsignal('rx_dv',   Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
-			Subsignal('rx_er',   Pins('F18', dir = 'i')),
+			Subsignal('rx_clk', Pins('K15', dir = 'i')),
+			Subsignal('rx_dv', Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
+			Subsignal('rx_er', Pins('F18', dir = 'i')),
 			Subsignal('rx_data', Pins('G16 H14 E16 F15 F14 E18 D16 D17', dir = 'i')),
-			Subsignal('col',     Pins('C17', dir = 'i')),
-			Subsignal('crs',     Pins('C18', dir = 'i')),
+			Subsignal('col', Pins('C17', dir = 'i')),
+			Subsignal('crs', Pins('C18', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('eth_rgmii', 0,
-			Subsignal('rst',     PinsN('G13', dir = 'o')),
-			Subsignal('int',     PinsN('L16', dir = 'o')),
-			Subsignal('mdio',    Pins('N17', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')), # Max 8.3MHz
-			Subsignal('tx_clk',  Pins('L12', dir = 'o')),
-			Subsignal('tx_ctl',  Pins('H15', dir = 'o')),
+		Resource(
+			'eth_rgmii', 0,
+			Subsignal('rst', PinsN('G13', dir = 'o')),
+			Subsignal('int', PinsN('L16', dir = 'o')),
+			Subsignal('mdio', Pins('N17', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')), # Max 8.3MHz
+			Subsignal('tx_clk', Pins('L12', dir = 'o')),
+			Subsignal('tx_ctl', Pins('H15', dir = 'o')),
 			Subsignal('tx_data', Pins('H16 H13 K14 K13', dir = 'o')),
-			Subsignal('rx_clk',  Pins('K15', dir = 'i')),
-			Subsignal('rx_ctl',  Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
+			Subsignal('rx_clk', Pins('K15', dir = 'i')),
+			Subsignal('rx_ctl', Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
 			Subsignal('rx_data', Pins('G16 H14 E16 F15', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('eth_mii', 0,
-			Subsignal('rst',     PinsN('G13', dir = 'o')),
-			Subsignal('int',     PinsN('L16', dir = 'o')),
-			Subsignal('mdio',    Pins('N17', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')), # Max 8.3MHz
-			Subsignal('tx_clk',  Pins('K16', dir = 'i')),
-			Subsignal('tx_en',   Pins('H15', dir = 'o')),
-			Subsignal('tx_er',   Pins('G18', dir = 'o')),
+		Resource(
+			'eth_mii', 0,
+			Subsignal('rst', PinsN('G13', dir = 'o')),
+			Subsignal('int', PinsN('L16', dir = 'o')),
+			Subsignal('mdio', Pins('N17', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')), # Max 8.3MHz
+			Subsignal('tx_clk', Pins('K16', dir = 'i')),
+			Subsignal('tx_en', Pins('H15', dir = 'o')),
+			Subsignal('tx_er', Pins('G18', dir = 'o')),
 			Subsignal('tx_data', Pins('H16 H13 K14 K13', dir = 'o')),
-			Subsignal('rx_clk',  Pins('K15', dir = 'i')),
-			Subsignal('rx_dv',   Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
-			Subsignal('rx_er',   Pins('F18', dir = 'i')),
+			Subsignal('rx_clk', Pins('K15', dir = 'i')),
+			Subsignal('rx_dv', Pins('F17', dir = 'i'), Attrs(PULLDOWN = 'TRUE')),
+			Subsignal('rx_er', Pins('F18', dir = 'i')),
 			Subsignal('rx_data', Pins('G16 H14 E16 F15', dir = 'i')),
-			Subsignal('col',     Pins('C17', dir = 'i')),
-			Subsignal('crs',     Pins('C18', dir = 'i')),
+			Subsignal('col', Pins('C17', dir = 'i')),
+			Subsignal('crs', Pins('C18', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 		# Device does not support RMII
-		Resource('eth_tbi', 0,
-			Subsignal('rst',     PinsN('G13', dir = 'o')),
-			Subsignal('int',     PinsN('L16', dir = 'o')),
-			Subsignal('mdio',    Pins('N17', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')), # Max 8.3MHz
-			Subsignal('tx_clk',  Pins('L12', dir = 'o')),
+		Resource(
+			'eth_tbi', 0,
+			Subsignal('rst', PinsN('G13', dir = 'o')),
+			Subsignal('int', PinsN('L16', dir = 'o')),
+			Subsignal('mdio', Pins('N17', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')), # Max 8.3MHz
+			Subsignal('tx_clk', Pins('L12', dir = 'o')),
 			Subsignal('tx_data', Pins('H16 H13 K14 K13 J13 G14 H12 K12 H15 G18', dir = 'o')),
-			Subsignal('rx_clk',  Pins('K15 L12', dir = 'i')),
+			Subsignal('rx_clk', Pins('K15 L12', dir = 'i')),
 			Subsignal('rx_data', Pins('G16 H14 E16 F15 F14 E18 D16 D17 F17 F18', dir = 'i')),
-			Subsignal('lpbk',    Pins('C17', dir = 'o'), Attrs(PULLDOWN = 'TRUE')),
-			Subsignal('comma',   Pins('C18', dir = 'i')),
+			Subsignal('lpbk', Pins('C17', dir = 'o'), Attrs(PULLDOWN = 'TRUE')),
+			Subsignal('comma', Pins('C18', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		Resource('eth_rtbi', 0,
-			Subsignal('rst',     PinsN('G13', dir = 'o')),
-			Subsignal('int',     PinsN('L16', dir = 'o')),
-			Subsignal('mdio',    Pins('N17', dir = 'io')),
-			Subsignal('mdc',     Pins('F16', dir = 'o')), # Max 8.3MHz
-			Subsignal('tx_clk',  Pins('L12', dir = 'o')),
+		Resource(
+			'eth_rtbi', 0,
+			Subsignal('rst', PinsN('G13', dir = 'o')),
+			Subsignal('int', PinsN('L16', dir = 'o')),
+			Subsignal('mdio', Pins('N17', dir = 'io')),
+			Subsignal('mdc', Pins('F16', dir = 'o')), # Max 8.3MHz
+			Subsignal('tx_clk', Pins('L12', dir = 'o')),
 			Subsignal('tx_data', Pins('H16 H13 K14 K13 H15', dir = 'o')),
-			Subsignal('rx_clk',  Pins('K15', dir = 'i')),
+			Subsignal('rx_clk', Pins('K15', dir = 'i')),
 			Subsignal('rx_data', Pins('G16 H14 E16 F15 F17', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('hdmi', 0, # J1, input only due to on board buffer, HDMI A connector
-			Subsignal('scl',     Pins('C13'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('sda',     Pins('A13'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('clk',     DiffPairs('D11', 'C11', dir = 'i')),
-			Subsignal('d',       DiffPairs('G9 B11 B12', 'F9 A11 A12', dir = 'i')),
+		Resource(
+			'hdmi', 0, # J1, input only due to on board buffer, HDMI A connector
+			Subsignal('scl',  Pins('C13'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('sda',  Pins('A13'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('clk', DiffPairs('D11', 'C11', dir = 'i')),
+			Subsignal('d', DiffPairs('G9 B11 B12', 'F9 A11 A12', dir = 'i')),
 			Attrs(IOSTANDARD = 'TMDS_33'),
 		),
-		Resource('hdmi', 1, # J2, output only due to on board buffer, HDMI A connector
-			Subsignal('scl',     Pins('D9'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('sda',     Pins('C9'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('clk',     DiffPairs('B6', 'A6', dir = 'o')),
-			Subsignal('d',       DiffPairs('D8 C7 B8', 'C8 A7 A8', dir = 'o')),
+		Resource(
+			'hdmi', 1, # J2, output only due to on board buffer, HDMI A connector
+			Subsignal('scl', Pins('D9'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('sda', Pins('C9'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('clk', DiffPairs('B6', 'A6', dir = 'o')),
+			Subsignal('d', DiffPairs('D8 C7 B8', 'C8 A7 A8', dir = 'o')),
 			Attrs(IOSTANDARD = 'TMDS_33'),
 		),
-		Resource('hdmi', 2, # J3, input only due to on board buffer, HDMI A connector
-			Subsignal('scl',     Pins('M16'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('sda',     Pins('M18'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('clk',     DiffPairs('H17', 'H18', dir = 'i')),
-			Subsignal('d',       DiffPairs('K17 L17 J16', 'K18 L18 J18', dir = 'i')),
+		Resource(
+			'hdmi', 2, # J3, input only due to on board buffer, HDMI A connector
+			Subsignal('scl', Pins('M16'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('sda', Pins('M18'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('clk', DiffPairs('H17', 'H18', dir = 'i')),
+			Subsignal('d', DiffPairs('K17 L17 J16', 'K18 L18 J18', dir = 'i')),
 			Attrs(IOSTANDARD = 'TMDS_33'),
 		),
-		Resource('hdmi', 3, # JA, input/output as it is unbuffered, HDMI D connector
-			Subsignal('scl',     Pins('C13'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('sda',     Pins('A13'), Attrs(IOSTANDARD = 'I2C')),
-			Subsignal('clk',     DiffPairs('T9', 'V9')),
-			Subsignal('d',       DiffPairs('R3 T4 N5', 'T3 V4 P6')),
+		Resource(
+			'hdmi', 3, # JA, input/output as it is unbuffered, HDMI D connector
+			Subsignal('scl', Pins('C13'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('sda', Pins('A13'), Attrs(IOSTANDARD = 'I2C')),
+			Subsignal('clk', DiffPairs('T9', 'V9')),
+			Subsignal('d', DiffPairs('R3 T4 N5', 'T3 V4 P6')),
 			Attrs(IOSTANDARD = 'TMDS_33'),
 		),
-
-		Resource('ac97', 0,
-			Subsignal('clk',     Pins('L13', dir = 'o')),
-			Subsignal('sync',    Pins('U17', dir = 'o')),
-			Subsignal('reset',   Pins('T17', dir = 'o')),
-			Subsignal('sdo',     Pins('N18', dir = 'o')),
-			Subsignal('sdi',     Pins('T18', dir = 'i')),
+		Resource(
+			'ac97', 0,
+			Subsignal('clk', Pins('L13', dir = 'o')),
+			Subsignal('sync', Pins('U17', dir = 'o')),
+			Subsignal('reset', Pins('T17', dir = 'o')),
+			Subsignal('sdo', Pins('N18', dir = 'o')),
+			Subsignal('sdi', Pins('T18', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 	]
 	connectors  = [
 		Connector('pmod', 0, 'T3 R3 P6 N5 - - V9 T9 V4 T4 - -'), # JB
-
-		Connector('vhdci', 0, # JC
-			'U16 - U15 U13 - M11 R11 - T12 N10 - M10 U11 - R10 - - - - U10 - R8  M8  - U8  U7  - N7  T6  - R7  N6  - U5 '
-			'V16 - V15 V13 - N11 T11 - V12 P11 - N9  V11 - T10 - - - - V10 - T8  N8  - V8  V7  - P8  V6  - T7  P7  - V5 '
+		Connector(
+			'vhdci', 0, # JC
+			'U16 - U15 U13 - M11 R11 - T12 N10 - M10 U11 - R10 - - - - U10 - R8  M8  - U8  U7  - N7  T6  - R7  N6  - U5'
+			'V16 - V15 V13 - N11 T11 - V12 P11 - N9  V11 - T10 - - - - V10 - T8  N8  - V8  V7  - P8  V6  - T7  P7  - V5'
 		),
 	]
 

--- a/torii_boards/xilinx/spartan6/numato_mimas.py
+++ b/torii_boards/xilinx/spartan6/numato_mimas.py
@@ -19,7 +19,6 @@ class NumatoMimasPlatform(XilinxPlatform):
 
 	resources   = [
 		Resource('clk100', 0, Pins('P126', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*LEDResources(
 			pins = 'P119 P118 P117 P116 P115 P114 P112 P111',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
@@ -28,20 +27,22 @@ class NumatoMimasPlatform(XilinxPlatform):
 			pins = 'P124 P123 P121 P120',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'TRUE')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'P38', clk = 'P70', copi = 'P64', cipo = '65',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 	]
 	connectors  = [
-		Connector('p', 1,
+		Connector(
+			'p', 1,
 			'-    -    P35  P34  P33  P32  P30  P29  P27  P26  '
 			'P24  P23  P22  P21  P17  P16  P15  P14  P12  P11  '
 			'P10  P9   P8   P7   P6   P5   P2   P1   P142 P141 '
 			'P140 P139 P138 P137 P134 P133 P132 P131 -    -    '
 		),
-		Connector('p', 2,
+		Connector(
+			'p', 2,
 			'-    -    P43  P44  P45  P46  P47  P48  P50  P51  '
 			'P55  P56  P74  P75  P78  P79  P80  P81  -    -    '
 			'P82  P83  P84  P85  P87  P88  P92  P93  P94  P95  '

--- a/torii_boards/xilinx/spartan6/sk_xc6slx9.py
+++ b/torii_boards/xilinx/spartan6/sk_xc6slx9.py
@@ -21,13 +21,13 @@ class SK_XC6SLX9Platform(XilinxPlatform):
 		Resource(
 			'clk50', 0, Pins('P134', dir = 'i'), Clock(50e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'P38', clk = 'P70', copi = 'P64', cipo = '65',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		SRAMResource(0,
+		SRAMResource(
+			0,
 			cs_n = 'P97', oe_n = 'P45', we_n = 'P51',
 			a = 'P39 P40 P41 P43 P44 P55 P56 P57 P58 P59 P82 P81 P80 P79 P78 P66 P62 P61 P60',
 			d = 'P46 P47 P48 P50 P75 P74 P69 P67',
@@ -35,19 +35,22 @@ class SK_XC6SLX9Platform(XilinxPlatform):
 		),
 	]
 	connectors  = [
-		Connector('x', 7,
+		Connector(
+			'x', 7,
 			'-    -    P34  -    P33  P32  P30  P29  P27  P26  '
 			'P24  P23  P22  P21  P17  P16  P15  P14  P12  P11  '
 			'P10  P9   P8   P7   P6   P5   P2   P1   P143 P144 '
 			'P141 P142 P139 P140 P137 P138 P132 P133 P127 P131 '
 		),
-		Connector('x', 9,
+		Connector(
+			'x', 9,
 			'-    -    P93  -    P92  P88  P87  P85  P84  P83  '
 			'P74  P75  P78  P79  P81  P80  P69  P82  P66  P67  '
 			'P61  P62  P59  P60  P58  P57  P55  P56  P50  P51  '
 			'P47  P48  P44  P46  P45  P43  P40  P41  P35  P39  '
 		),
-		Connector('x', 8,
+		Connector(
+			'x', 8,
 			'-    -    P126 -    P123 P124 P120 P121 P118 P119 '
 			'P116 P117 P114 P115 P111 P112 P104 P105 P101 P102 '
 			'P99  P100 P97  P98  P94  P95  -    -    -    -    '

--- a/torii_boards/xilinx/spartan7/arty_s7.py
+++ b/torii_boards/xilinx/spartan7/arty_s7.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
+from textwrap                     import dedent
+
 from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run              import BuildPlan, BuildProducts
 from torii.hdl.ir                 import Fragment
@@ -25,51 +27,51 @@ class _ArtyS7Platform(XilinxPlatform):
 			'clk100', 0, Pins('R2', dir = 'i'), Clock(100e6), Attrs(IOSTANDARD = 'SSTL135')
 		),
 		Resource('rst', 0, PinsN('C18', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*LEDResources(pins = 'E18 F13 E13 H15', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		RGBLEDResource(0, r = 'J15', g = 'G17', b = 'F15', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		RGBLEDResource(1, r = 'E15', g = 'F18', b = 'E14', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		*ButtonResources(pins = 'G15 K16 J16 H13', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
 		*SwitchResources(pins = 'H14 H18 G18  M5', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'V12', tx = 'R12',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		SPIResource(0,
+		SPIResource(
+			0,
 			cs_n = 'H16', clk = 'G16', copi = 'H17', cipo = 'K14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		I2CResource(0,
+		I2CResource(
+			0,
 			scl = 'J14', sda = 'J13',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'M13', clk = 'D11', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M15',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('ddr3', 0,
-			Subsignal('rst',    PinsN('J6', dir = 'o')),
-			Subsignal('clk',    DiffPairs('R5', 'T4', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL135')),
+		Resource(
+			'ddr3', 0,
+			Subsignal('rst', PinsN('J6', dir = 'o')),
+			Subsignal('clk', DiffPairs('R5', 'T4', dir = 'o'), Attrs(IOSTANDARD = 'DIFF_SSTL135')),
 			Subsignal('clk_en', Pins('T2', dir = 'o')),
-			Subsignal('cs',     PinsN('R3', dir = 'o')),
-			Subsignal('we',     PinsN('P7', dir = 'o')),
-			Subsignal('ras',    PinsN('U1', dir = 'o')),
-			Subsignal('cas',    PinsN('V3', dir = 'o')),
-			Subsignal('a',      Pins('U2 R4 V2 V4 T3 R7 V6 T6 U7 V7 P6 T5 R6 U6', dir = 'o')),
-			Subsignal('ba',     Pins('V5 T1 U3', dir = 'o')),
-			Subsignal('dqs',    DiffPairs('K1 N3', 'L1 N2', dir = 'io'),
-								Attrs(IOSTANDARD = 'DIFF_SSTL135')),
-			Subsignal('dq',     Pins('K2 K3 L4 M6 K6 M4 L5 L6 N4 R1 N1 N5 M2 P1 M1 P2', dir = 'io'),
-								Attrs(IN_TERM = 'UNTUNED_SPLIT_40')),
-			Subsignal('dm',     Pins('K4 M3', dir = 'o')),
-			Subsignal('odt',    Pins('P5', dir = 'o')),
+			Subsignal('cs', PinsN('R3', dir = 'o')),
+			Subsignal('we', PinsN('P7', dir = 'o')),
+			Subsignal('ras', PinsN('U1', dir = 'o')),
+			Subsignal('cas', PinsN('V3', dir = 'o')),
+			Subsignal('a', Pins('U2 R4 V2 V4 T3 R7 V6 T6 U7 V7 P6 T5 R6 U6', dir = 'o')),
+			Subsignal('ba', Pins('V5 T1 U3', dir = 'o')),
+			Subsignal(
+				'dqs', DiffPairs('K1 N3', 'L1 N2', dir = 'io'), Attrs(IOSTANDARD = 'DIFF_SSTL135')
+			),
+			Subsignal(
+				'dq', Pins('K2 K3 L4 M6 K6 M4 L5 L6 N4 R1 N1 N5 M2 P1 M1 P2', dir = 'io'),
+				Attrs(IN_TERM = 'UNTUNED_SPLIT_40')
+			),
+			Subsignal('dm', Pins('K4 M3', dir = 'o')),
+			Subsignal('odt', Pins('P5', dir = 'o')),
 			Attrs(IOSTANDARD = 'SSTL135', SLEW = 'FAST'),
 		),
 	]
@@ -78,24 +80,22 @@ class _ArtyS7Platform(XilinxPlatform):
 		Connector('pmod', 1, 'P17 P18 R18 T18 - - P14 P15 N15 P16 - -'), # JB
 		Connector('pmod', 2, 'U15 V16 U17 U18 - - U16 P13 R13 V14 - -'), # JC
 		Connector('pmod', 3, 'V15 U12 V13 T12 - - T13 R11 T11 U11 - -'), # JD
-
 		Connector('ck_io', 0, {
 			# Outer Digital Header
-			'io0':  'L13',
-			'io1':  'N13',
-			'io2':  'L16',
-			'io3':  'R14',
-			'io4':  'T14',
-			'io5':  'R16',
-			'io6':  'R17',
-			'io7':  'V17',
-			'io8':  'R15',
-			'io9':  'T15',
+			'io0': 'L13',
+			'io1': 'N13',
+			'io2': 'L16',
+			'io3': 'R14',
+			'io4': 'T14',
+			'io5': 'R16',
+			'io6': 'R17',
+			'io7': 'V17',
+			'io8': 'R15',
+			'io9': 'T15',
 			'io10': 'H16',
 			'io11': 'H17',
 			'io12': 'K14',
 			'io13': 'G16',
-
 			# Inner Digital Header
 			'io26': 'U11',
 			'io27': 'T11',
@@ -113,7 +113,6 @@ class _ArtyS7Platform(XilinxPlatform):
 			'io39': 'U17',
 			'io40': 'V16',
 			'io41': 'U15',
-
 			# Outer Analog Header as Digital IO
 			'a0': 'G13',
 			'a1': 'B16',
@@ -121,7 +120,6 @@ class _ArtyS7Platform(XilinxPlatform):
 			'a3': 'C13',
 			'a4': 'C14',
 			'a5': 'D18',
-
 			# Inner Analog Header as Digital IO
 			'io20': 'B14',
 			'io21': 'A14',
@@ -144,7 +142,6 @@ class _ArtyS7Platform(XilinxPlatform):
 			'vaux10_n': 'B18',
 			'vaux11_p': 'E16',
 			'vaux11_n': 'E17',
-
 			# Inner Analog Header
 			'vaux8_p': 'B14',
 			'vaux8_n': 'A14',
@@ -155,20 +152,16 @@ class _ArtyS7Platform(XilinxPlatform):
 
 	def toolchain_prepare(self, fragment: Fragment, name: str, **kwargs) -> BuildPlan:
 		overrides = {
-			'script_before_bitstream':
-				'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
-			'script_after_bitstream':
-				'write_cfgmem -force -format mcs -interface spix4 -size 16 '
-				f'-loadbit \'up 0x0 {name}.bit\' -file {name}.mcs',
-			'add_constraints':
-				'set_property INTERNAL_VREF 0.675 [get_iobanks 34]'
+			'script_before_bitstream': 'set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]',
+			'script_after_bitstream': dedent(f'''
+				write_cfgmem -force -format mcs -interface spix4 -size 16 -loadbit 'up 0x0 {name}.bit' -file {name}.mcs
+			'''),
+			'add_constraints': 'set_property INTERNAL_VREF 0.675 [get_iobanks 34]'
 		}
 		return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 
 	def _program_vivado(self, products: BuildProducts, name: str, flash: bool) -> None:
 		from subprocess  import run
-		from textwrap    import dedent
-
 		from torii.tools import require_tool
 
 		vivado = require_tool('vivado')
@@ -195,7 +188,7 @@ class _ArtyS7Platform(XilinxPlatform):
 					create_hw_bitstream -hw_device [current_hw_device] [get_property PROGRAM.HW_CFGMEM_BITFILE [current_hw_device]]
 					program_hw_devices
 					program_hw_cfgmem
-				''')
+				''') # noqa: E501
 			else:
 				cmd_script += dedent(f'''
 					set_property PROGRAM.FILE {{{bitstream}}} [current_hw_device]

--- a/torii_boards/xilinx/spartan7/cmod_s7.py
+++ b/torii_boards/xilinx/spartan7/cmod_s7.py
@@ -34,45 +34,41 @@ class CmodS7_Platform(XilinxPlatform):
 		Resource(
 			'clk12', 0, Pins('M9', dir = 'i'), Clock(12e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(pins = 'E2 K1 J1 E1', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
-		RGBLEDResource(0,
+		RGBLEDResource(
+			0,
 			r = 'F2', g = 'D3', b = 'F1', invert = True,
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*ButtonResources(pins = 'D2 D1', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		UARTResource(0, rx = 'L12', tx = 'K15', attrs = Attrs(IOSTANDARD = 'LVCMOS33')),
-
 		# Clock only via STARTUPE2 primitive
-		*SPIFlashResources(0,
+		*SPIFlashResources(
+			0,
 			cs_n = 'L11', clk = 'F5', copi = 'H14', cipo = 'H15', wp_n = 'J12',
 			hold_n = 'K13',
 			attrs = Attrs(IOSTANDARD='LVCMOS33')
 		),
-
 		# One-wire interface to crypto authentication device
 		# May not be populated on the board
 		Resource('atsha204a', 0, Pins('D17', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33'))
 	]
+
 	connectors  = [
 		Connector('pmod', 0, 'J2 H2 H4 F3 - - H3 H1 G1 F4 - -'), # JA
-
 		# Pin 24/25 are VCC and GND
 		# Pin 32/33 are analog (XADC)
 		# Pin 9-15 and 34-39 do not exist
-		Connector('gpio', 0,
+		Connector(
+			'gpio', 0,
 			'L1  M4  M3  N2  M2  P3  N3  P1  N1  -   -   -  '
 			'-   -   -   P14 P15 N13 N15 N14 M15 M14 L15 -  '
 			'-   L14 K14 J15 L13 M13 J11 -   -   -   -   -  '
 			'-   -   -   C5  A2  B2  B1  C1  B3  B4  A3  A4 '
 		),
-
 		Connector('xadc', 0, {
-			'vaux5_n':  'A13',
-			'vaux5_p':  'A14',
+			'vaux5_n': 'A13',
+			'vaux5_p': 'A14',
 			'vaux12_n': 'A11',
 			'vaux12_p': 'A12'
 		})
@@ -83,7 +79,6 @@ class CmodS7_Platform(XilinxPlatform):
 			subprocess.check_call([
 				'openFPGALoader', '-c', 'digilent', '--fpga-part', self.device, bitstream_filename
 			])
-
 
 if __name__ == '__main__':
 	from ...test.blinky import Blinky

--- a/torii_boards/xilinx/zynq7/arty_z7.py
+++ b/torii_boards/xilinx/zynq7/arty_z7.py
@@ -22,63 +22,57 @@ class ArtyZ720Platform(XilinxPlatform):
 		Resource(
 			'clk125', 0, Pins('H16', dir = 'i'), Clock(125e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*SwitchResources(
 			pins = 'M20 M19',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		RGBLEDResource(0,
-			r = 'N15', g = 'G17', b = 'L15',                    # LD4
+		RGBLEDResource(
+			0, # LD4
+			r = 'N15', g = 'G17', b = 'L15',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-		RGBLEDResource(1,                                       # LD5
+		RGBLEDResource(
+			1,  # LD5
 			r = 'M15', g = 'L14', b = 'G14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(
 			pins = 'R14 P14 N16 M14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*ButtonResources(
 			pins = 'D19 D20 L20 L19',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('audio', 0,
+		Resource(
+			'audio', 0,
 			Subsignal('pwm', Pins('R18', dir = 'o')),
 			Subsignal('sd',  PinsN('T17', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('crypto_sda', 0,                               # ATSHA204A
+		Resource(
+			'crypto_sda', 0, # ATSHA204A
 			Pins('J15', dir = 'io'),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('hdmi_rx', 0,                                  # J10
+		Resource(
+			'hdmi_rx', 0, # J10
 			Subsignal('cec', Pins('H17', dir = 'io')),
-			Subsignal('clk', DiffPairs('N18', 'P19', dir = 'i'),
-				Attrs(IOSTANDARD = 'TMDS_33')
-			),
-			Subsignal('d',   DiffPairs('V20 T20 N20', 'W20 U20 P20', dir = 'i'),
-				Attrs(IOSTANDARD = 'TMDS_33')
+			Subsignal('clk', DiffPairs('N18', 'P19', dir = 'i'), Attrs(IOSTANDARD = 'TMDS_33')),
+			Subsignal(
+				'd', DiffPairs('V20 T20 N20', 'W20 U20 P20', dir = 'i'), Attrs(IOSTANDARD = 'TMDS_33')
 			),
 			Subsignal('hpd', Pins('T19', dir = 'o')),
 			Subsignal('scl', Pins('U14', dir = 'io')),
 			Subsignal('sda', Pins('U15', dir = 'io')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		Resource('hdmi_tx', 0,                                  # J11
+		Resource(
+			'hdmi_tx', 0, # J11
 			Subsignal('cec', Pins('G15', dir = 'io')),
-			Subsignal('clk', DiffPairs('L16', 'L17', dir = 'o'),
-				Attrs(IOSTANDARD = 'TMDS_33')
-			),
-			Subsignal('d',   DiffPairs('K17 K19 J18', 'K18 J19 H18', dir = 'o'),
-				Attrs(IOSTANDARD = 'TMDS_33')
+			Subsignal('clk', DiffPairs('L16', 'L17', dir = 'o'), Attrs(IOSTANDARD = 'TMDS_33')),
+			Subsignal(
+				'd', DiffPairs('K17 K19 J18', 'K18 J19 H18', dir = 'o'), Attrs(IOSTANDARD = 'TMDS_33')
 			),
 			Subsignal('hpd', PinsN('R19', dir = 'i')),
 			Subsignal('scl', Pins('M17', dir = 'io')),
@@ -86,10 +80,10 @@ class ArtyZ720Platform(XilinxPlatform):
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		)
 	]
+
 	connectors = [
 		Connector('pmod', 0, 'Y18 Y19 Y16 Y17 - - U18 U19 W18 W19 - -'),  # JA
 		Connector('pmod', 1, 'W14 Y14 T11 T10 - - V16 W16 V12 W13 - -'),  # JB
-
 		Connector('ck_io', 0, {
 			# Outer Digital Header
 			'io0': 'T14',
@@ -106,7 +100,6 @@ class ArtyZ720Platform(XilinxPlatform):
 			'io11': 'R17',
 			'io12': 'P18',
 			'io13': 'N17',
-
 			# Inner Digital Header
 			'io26': 'U5',
 			'io27': 'V5',
@@ -124,7 +117,6 @@ class ArtyZ720Platform(XilinxPlatform):
 			'io39': 'Y8',
 			'io40': 'W9',
 			'io41': 'Y9',
-
 			# Outer Analog Header as Digital IO
 			'a0': 'Y11',
 			'a1': 'Y12',
@@ -132,7 +124,6 @@ class ArtyZ720Platform(XilinxPlatform):
 			'a3': 'V11',
 			'a4': 'T5',
 			'a5': 'U10',
-
 			# Inner Analog Header as Digital IO
 			'a6': 'F19',
 			'a7': 'F20',
@@ -140,23 +131,19 @@ class ArtyZ720Platform(XilinxPlatform):
 			'a9': 'B20',
 			'a10': 'B19',
 			'a11': 'A20',
-
 			# Misc.
 			'a': 'Y13'
 		}),
-
 		Connector('ck_spi', 0, {
 			'cipo': 'W15',
 			'copi': 'T12',
 			'sck': 'H15',
 			'ss': 'F16'
 		}),
-
 		Connector('ck_i2c', 0, {
 			'scl': 'P16',
 			'sda': 'P15'
 		}),
-
 		Connector('xadc', 0, {
 			# Outer Analog Header
 			'vaux1_n': 'D18',
@@ -171,7 +158,6 @@ class ArtyZ720Platform(XilinxPlatform):
 			'vaux5_p': 'J20',
 			'vaux13_n': 'G20',
 			'vaux13_p': 'G19',
-
 			# Inner Analog Header
 			'vaux12_n': 'F20',
 			'vaux12_p': 'F19',

--- a/torii_boards/xilinx/zynq7/ebaz4205.py
+++ b/torii_boards/xilinx/zynq7/ebaz4205.py
@@ -22,20 +22,18 @@ class EBAZ4205Platform(XilinxPlatform):
 		Resource(
 			'clk33_333', 0, Pins('N18', dir = 'i'), Clock(33.333e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
 		*LEDResources(
 			pins = 'W14 W13',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
-
-		UARTResource(0,
+		UARTResource(
+			0,
 			rx = 'B19', tx = 'B20',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
 	]
 
-	connectors = [
-	]
+	connectors = []
 
 	def toolchain_program(self, products: BuildProducts, name: str, **kwargs) -> None:
 		from os         import environ

--- a/torii_boards/xilinx/zynq7/microzed_z010.py
+++ b/torii_boards/xilinx/zynq7/microzed_z010.py
@@ -17,7 +17,8 @@ class MicroZedZ010Platform(XilinxPlatform):
 
 	resources  = []
 	connectors = [
-		Connector('JX1', 0,
+		Connector(
+			'JX1', 0,
 			'F9  J6  '
 			'F6  G6  '
 			'-   -   '
@@ -69,7 +70,8 @@ class MicroZedZ010Platform(XilinxPlatform):
 			'K9  M9  '
 			'L10 M10 '
 		),
-		Connector('JX2', 0,
+		Connector(
+			'JX2', 0,
 			'E8  E9  '
 			'C6  D9  '
 			'E6  B5  '

--- a/torii_boards/xilinx/zynq7/microzed_z020.py
+++ b/torii_boards/xilinx/zynq7/microzed_z020.py
@@ -17,7 +17,8 @@ class MicroZedZ020Platform(XilinxPlatform):
 
 	resources  = []
 	connectors = [
-		Connector('JX1', 0,
+		Connector(
+			'JX1', 0,
 			'F9  J6  '
 			'F6  G6  '
 			'-   -   '
@@ -69,7 +70,8 @@ class MicroZedZ020Platform(XilinxPlatform):
 			'K9  M9  '
 			'L10 M10 '
 		),
-		Connector('JX2', 0,
+		Connector(
+			'JX2', 0,
 			'E8  E9  '
 			'C6  D9  '
 			'E6  B5  '

--- a/torii_boards/xilinx/zynq7/zturn_lite_z007s.py
+++ b/torii_boards/xilinx/zynq7/zturn_lite_z007s.py
@@ -17,7 +17,8 @@ class ZTurnLiteZ007SPlatform(XilinxPlatform):
 
 	resources  = []
 	connectors = [
-		Connector('expansion', 0,
+		Connector(
+			'expansion', 0,
 			'-   -   '
 			'B19 E17 '
 			'A20 D18 '


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR fixes an issue that was found where the `flake8` formatting rules were not consistent with Torii, and also the exclusions caused a large blindspot.

There is also an issue where `flake8` won't report some overly-long-lines, but Ruff does, so we run both `flake8` and ruff in the lint pass now. This also syncs the `flake8` rules with Ruff in the `pyproject.toml`.

This PR also normalized the formatting of all the board files, and fixes an issue where some of the connectors were not formatted properly causing them to not behave correctly.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii Boards [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii Boards and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md#ai-usage-policy
