### PR TITLE
Cleanup Platform Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Unreleased template stuff
 
 ### Fixed
 
+- All board files now use the appropriate Torii platform resources where possible.
+
 ## [0.8.0] - 2025-06-26
 
 This is a maintenance release, syncs the minimum [Torii] version to `0.8.0` in preparation for

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,2 +1,6 @@
+---
+tocdepth: 2
+---
+<!-- markdownlint-disable MD041 -->
 ```{include} ../CHANGELOG.md
 ```

--- a/torii_boards/altera/cyclone_iii/de0.py
+++ b/torii_boards/altera/cyclone_iii/de0.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	ButtonResources, Display7SegResource, LEDResources, NORFlashResources, PS2Resource, SDCardResources, SDRAMResource,
-	SwitchResources, UARTResource, VGAResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import PS2Resource, UARTResource
+from torii.platform.resources.memory    import NORFlashResources, SDCardResources, SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'DE0Platform',

--- a/torii_boards/altera/cyclone_iv/rz_easyfpga_a2_2.py
+++ b/torii_boards/altera/cyclone_iv/rz_easyfpga_a2_2.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
+from textwrap                           import dedent
 
-from torii.build                  import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.hdl.ir                 import Fragment
-from torii.platform.resources     import (
-	ButtonResources, Display7SegResource, I2CResource, LEDResources, PS2Resource, SDRAMResource, UARTResource,
-	VGAResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.hdl.ir                       import Fragment
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import I2CResource, PS2Resource, UARTResource
+from torii.platform.resources.memory    import SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'RZEasyFPGAA2_2Platform',

--- a/torii_boards/altera/cyclone_v/chameleon96.py
+++ b/torii_boards/altera/cyclone_v/chameleon96.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Connector, Pins, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import I2CResource, LEDResources, SDCardResources, UARTResource
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Connector, Pins, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.interface import I2CResource, UARTResource
+from torii.platform.resources.memory    import SDCardResources
+from torii.platform.resources.user      import LEDResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'Chameleon96Platform',

--- a/torii_boards/altera/cyclone_v/de0_cv.py
+++ b/torii_boards/altera/cyclone_v/de0_cv.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	ButtonResources, Display7SegResource, LEDResources, PS2Resource, SDCardResources, SDRAMResource,
-	SwitchResources, VGAResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import PS2Resource
+from torii.platform.resources.memory    import SDCardResources, SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'DE0CVPlatform',

--- a/torii_boards/altera/cyclone_v/de10_nano.py
+++ b/torii_boards/altera/cyclone_v/de10_nano.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	ButtonResources, LEDResources, SPIResource, SwitchResources, UARTResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.interface import SPIResource, UARTResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'DE10NanoPlatform',

--- a/torii_boards/altera/cyclone_v/de1_soc.py
+++ b/torii_boards/altera/cyclone_v/de1_soc.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import ButtonResources, Display7SegResource, LEDResources, SwitchResources
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                      import Attrs, Clock, Connector, Pins, Resource
+from torii.build.run                  import BuildProducts
+from torii.platform.resources.display import Display7SegResource
+from torii.platform.resources.user    import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera     import AlteraPlatform
 
 __all__ = (
 	'DE1SoCPlatform',

--- a/torii_boards/altera/cyclone_v/mister.py
+++ b/torii_boards/altera/cyclone_v/mister.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	ButtonResources, LEDResources, SDCardResources, SDRAMResource, SPIResource, SwitchResources,
-	UARTResource, VGAResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.display   import VGAResource
+from torii.platform.resources.interface import SPIResource, UARTResource
+from torii.platform.resources.memory    import SDCardResources, SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'MisterPlatform',

--- a/torii_boards/altera/max10/arrow_deca.py
+++ b/torii_boards/altera/max10/arrow_deca.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
+from textwrap                      import dedent
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import ButtonResources, LEDResources, SwitchResources
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                   import Attrs, Clock, Connector, Pins, Resource
+from torii.build.run               import BuildProducts
+from torii.platform.resources.user import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera  import AlteraPlatform
 
 __all__ = (
 	'ArrowDECAPlatform',

--- a/torii_boards/altera/max10/de10_lite.py
+++ b/torii_boards/altera/max10/de10_lite.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	ButtonResources, Display7SegResource, LEDResources, SDRAMResource, SwitchResources, UARTResource, VGAResource
-)
-from torii.platform.vendor.altera import AlteraPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.altera       import AlteraPlatform
 
 __all__ = (
 	'DE10LitePlatform',

--- a/torii_boards/gowin/gw1n/tang_nano.py
+++ b/torii_boards/gowin/gw1n/tang_nano.py
@@ -2,9 +2,11 @@
 
 import subprocess
 
-from torii.build                 import Attrs, Clock, Pins, Resource, Subsignal
-from torii.platform.resources    import ButtonResources, RGBLEDResource, SPIFlashResources, UARTResource
-from torii.platform.vendor.gowin import GowinPlatform
+from torii.build                        import Attrs, Clock, Pins, Resource, Subsignal
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, RGBLEDResource
+from torii.platform.vendor.gowin        import GowinPlatform
 
 __all__ = (
 	'TangNanoPlatform',
@@ -33,6 +35,7 @@ class TangNanoPlatform(GowinPlatform):
 			cs_n = '19', clk = '20', copi = '22', cipo = '23', wp_n = '24', hold_n = '25',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `LCDResource` when in Torii
 		Resource(
 			'lcd', 0,
 			Subsignal('clk', Pins('11', dir = 'o')),

--- a/torii_boards/lattice/ecp5/colorlight_5a75b_r7_0.py
+++ b/torii_boards/lattice/ecp5/colorlight_5a75b_r7_0.py
@@ -3,7 +3,9 @@
 from torii.build                        import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import ButtonResources, LEDResources, SDRAMResource, UARTResource
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -36,6 +38,9 @@ class Colorlight_5A75B_R70Platform(ECP5Platform):
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		# SPIFlash (W25Q32JV)   1x/2x/4x speed
+		# XXX(aki):
+		# We can't replace this with `SPIFlashResource` because it needs a `clk` signal
+		# And the SPI Clock needs to be done via the `USRMCLK` block in the ECP5.
 		Resource(
 			'spi_flash', 0,
 			Subsignal('cs', PinsN('N8', dir = 'o')),
@@ -59,6 +64,7 @@ class Colorlight_5A75B_R70Platform(ECP5Platform):
 			attrs = Attrs(PULLMODE = 'NONE', DRIVE = '4', SLEWRATE = 'FAST', IO_TYPE = 'LVCMOS33')
 		),
 		# Broadcom B50612D Gigabit Ethernet Transceiver
+		# TODO(aki): Replace with `EthernetResource` when it gets an `rst` signal
 		Resource(
 			'eth_rgmii', 0,
 			Subsignal('rst', PinsN('P5', dir = 'o')),
@@ -73,6 +79,7 @@ class Colorlight_5A75B_R70Platform(ECP5Platform):
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		# Broadcom B50612D Gigabit Ethernet Transceiver
+		# TODO(aki): Replace with `EthernetResource` when it gets an `rst` signal
 		Resource(
 			'eth_rgmii', 1,
 			Subsignal('rst', PinsN('P5', dir = 'o')),
@@ -86,7 +93,6 @@ class Colorlight_5A75B_R70Platform(ECP5Platform):
 			Subsignal('rx_data', Pins('P13 N13 P14 M15', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-
 	]
 	connectors = [
 		Connector('j', 1, 'F3 F1 G3 - G2 H3 H5 F15 L2 K1 J5 K2 B16 J14 F12 -'),

--- a/torii_boards/lattice/ecp5/ecp5_5g_evn.py
+++ b/torii_boards/lattice/ecp5/ecp5_5g_evn.py
@@ -5,9 +5,9 @@ from typing                             import Literal
 
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildProducts
-from torii.platform.resources           import (
-	ButtonResources, LEDResources, SPIFlashResources, SwitchResources, UARTResource
-)
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (

--- a/torii_boards/lattice/ecp5/ecpix5.py
+++ b/torii_boards/lattice/ecp5/ecpix5.py
@@ -2,7 +2,9 @@
 
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildProducts
-from torii.platform.resources           import RGBLEDResource, SPIFlashResources, UARTResource, ULPIResource
+from torii.platform.resources.interface import UARTResource, ULPIResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import RGBLEDResource
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -51,6 +53,7 @@ class _ECPIX5Platform(ECP5Platform):
 			cs_n = 'AA2', clk = 'AE3', cipo = 'AE2', copi = 'AD2', wp_n = 'AF2', hold_n = 'AE1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `EthernetResource` when it gets an `rst` signal
 		Resource(
 			'eth_rgmii', 0,
 			Subsignal('rst', PinsN('C13', dir = 'o')),
@@ -65,6 +68,7 @@ class _ECPIX5Platform(ECP5Platform):
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
 		Resource('eth_int', 0, PinsN('B13', dir = 'i'), Attrs(IO_TYPE = 'LVCMOS33')),
+		# TODO(aki): Replace with `DDR3Resource` when it can have more fine-grained attrs
 		Resource(
 			'ddr3', 0,
 			Subsignal('clk', DiffPairs('H3', 'J3', dir = 'o'), Attrs(IO_TYPE = 'SSTL15D_I')),

--- a/torii_boards/lattice/ecp5/logicbone.py
+++ b/torii_boards/lattice/ecp5/logicbone.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, Resource, Subsignal
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import (
-	ButtonResources, DirectUSBResource, LEDResources, SDCardResources, SPIFlashResources
-)
+from torii.platform.resources.interface import DirectUSBResource
+from torii.platform.resources.memory    import DDR3Resource, SDCardResources, SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -65,6 +65,7 @@ class LogicbonePlatform(ECP5Platform):
 		Resource(
 			'eth_clk125', 0, Pins('A19', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `EthernetResource` when it supports `int` signal
 		Resource(
 			'eth_rgmii', 0,
 			# Stolen for sys_reset usage on prototypes.
@@ -80,22 +81,16 @@ class LogicbonePlatform(ECP5Platform):
 			Subsignal('rx_data', Pins('B17 A17 B16 A16', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
-		Resource(
-			'ddr3', 0,
-			Subsignal('rst', PinsN('P1', dir = 'o')),
-			Subsignal('clk', DiffPairs('M4', 'N5', dir = 'o'), Attrs(IO_TYPE = 'LVDS')),
-			Subsignal('clk_en', Pins('K4', dir = 'o')),
-			Subsignal('cs', PinsN('M3', dir = 'o')),
-			Subsignal('we', PinsN('E4', dir = 'o')),
-			Subsignal('ras', PinsN('L1', dir = 'o')),
-			Subsignal('cas', PinsN('M1', dir = 'o')),
-			Subsignal('a', Pins('D5 F4 B3 F3 E5 C3 C4 A5 A3 B5 G3 F5 D2 A4 D3 E3', dir = 'o')),
-			Subsignal('ba', Pins('B4 H5 N2', dir = 'o')),
-			Subsignal('dqs', DiffPairs('K2 H4', 'J1 G5', dir = 'io'), Attrs(IO_TYPE = 'LVDS')),
-			Subsignal('dq', Pins('G2 K1 F1 K3 H2 J3 G1 H1 B1 E1 A2 F2 C1 E2 C2 D1', dir = 'io')),
-			Subsignal('dm', Pins('L4 J5', dir = 'o')),
-			Subsignal('odt', Pins('C5', dir = 'o')),
-			Attrs(IO_TYPE = 'SSTL135_I')
+		DDR3Resource(
+			0,
+			rst_n = 'P1',
+			clk_p = 'M4', clk_n = 'N5', clk_en = 'K4',
+			cs_n = 'M3', we_n = 'E4', ras_n = 'L1', cas_n = 'M1',
+			a = 'D5 F4 B3 F3 E5 C3 C4 A5 A3 B5 G3 F5 D2 A4 D3 E3', ba = 'B4 H5 N2',
+			dqs_p = 'K2 H4', dqs_n = 'J1 G5',
+			dq = 'G2 K1 F1 K3 H2 J3 G1 H1 B1 E1 A2 F2 C1 E2 C2 D1', dm = 'L4 J5', odt = 'C5',
+			diff_attrs = Attrs(IO_TYPE = 'LVDS'),
+			attrs = Attrs(IO_TYPE = 'SSTL135_I')
 		)
 	]
 	connectors = [

--- a/torii_boards/lattice/ecp5/orangecrab_r0_1.py
+++ b/torii_boards/lattice/ecp5/orangecrab_r0_1.py
@@ -3,7 +3,9 @@
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import DirectUSBResource, RGBLEDResource, SDCardResources, SPIFlashResources
+from torii.platform.resources.interface import DirectUSBResource
+from torii.platform.resources.memory    import SDCardResources, SPIFlashResources
+from torii.platform.resources.user      import RGBLEDResource
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -34,7 +36,7 @@ class OrangeCrabR0_1Platform(ECP5Platform):
 			cs_n = 'U17', clk = 'U16', cipo = 'T18', copi = 'U18', wp_n = 'R18', hold_n = 'N18',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33'),
 		),
-		# TODO(aki): Replace with DDR3Resource
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('B1', dir = 'o')),

--- a/torii_boards/lattice/ecp5/orangecrab_r0_2.py
+++ b/torii_boards/lattice/ecp5/orangecrab_r0_2.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import (
-	ButtonResources, DirectUSBResource, RGBLEDResource, SDCardResources, SPIFlashResources
-)
+from torii.platform.resources.interface import DirectUSBResource
+from torii.platform.resources.memory    import SDCardResources, SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, RGBLEDResource
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 # NOTE: Keep OrangeCrabR0_2FPlatform for backwards compatibility
@@ -46,7 +45,7 @@ class OrangeCrabR0_2Platform(ECP5Platform):
 			cs_n = 'U17', clk = 'U16', cipo = 'T18', copi = 'U18', wp_n = 'R18', hold_n = 'N18',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33'),
 		),
-		# TODO(aki): Replace with DDR3Resource
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('L18', dir = 'o')),

--- a/torii_boards/lattice/ecp5/supercon19badge.py
+++ b/torii_boards/lattice/ecp5/supercon19badge.py
@@ -5,9 +5,9 @@ from torii.build                        import (
 )
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import (
-	ButtonResources, DirectUSBResource, LEDResources, SDRAMResource, UARTResource
-)
+from torii.platform.resources.interface import DirectUSBResource, UARTResource
+from torii.platform.resources.memory    import SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -82,7 +82,7 @@ class Supercon19BadgePlatform(ECP5Platform):
 			Subsignal('b', Pins('E2', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS33', PULLMODE = 'UP')
 		),
-		# Direct HDMI on the bottom of the board.
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi', 0,
 			Subsignal('clk', DiffPairsN('P20', 'R20'), Attrs(IO_TYPE = 'TMDS_33')),
@@ -105,8 +105,11 @@ class Supercon19BadgePlatform(ECP5Platform):
 			Subsignal('blen', Pins('P5')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# XXX(aki):
+		# We can't replace this with `SPIFlashResource` because it needs a `clk` signal
+		# And the SPI Clock needs to be done via the `USRMCLK` block in the ECP5.
 		Resource(
-			'spi_flash', 0, # clock needs to be accessed through USRMCLK
+			'spi_flash', 0,
 			Subsignal('cs', PinsN('R2')),
 			Subsignal('copi', Pins('W2')),
 			Subsignal('cipo', Pins('V2')),
@@ -114,12 +117,16 @@ class Supercon19BadgePlatform(ECP5Platform):
 			Subsignal('hold', Pins('W1')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# XXX(aki):
+		# We can't replace this with `SPIFlashResource` because it needs a `clk` signal
+		# And the SPI Clock needs to be done via the `USRMCLK` block in the ECP5.
 		Resource(
-			'spi_flash_4x', 0, # clock needs to be accessed through USRMCLK
+			'spi_flash_4x', 0,
 			Subsignal('cs', PinsN('R2')),
 			Subsignal('dq', Pins('W2 V2 Y2 W1')),
 			Attrs(IO_TYPE = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `SPIResource` when it's QSPI compatible
 		# SPI-connected PSRAM.
 		Resource(
 			'spi_psram_4x', 0,
@@ -128,6 +135,7 @@ class Supercon19BadgePlatform(ECP5Platform):
 			Subsignal('dq', Pins('E19 D19 C20 F19'), Attrs(PULLMODE = 'UP')),
 			Attrs(IO_TYPE = 'LVCMOS33', SLEWRATE = 'SLOW')
 		),
+		# TODO(aki): Replace with `SPIResource` when it's QSPI compatible
 		Resource(
 			'spi_psram_4x', 1,
 			Subsignal('cs', PinsN('F20')),

--- a/torii_boards/lattice/ecp5/ulx3s.py
+++ b/torii_boards/lattice/ecp5/ulx3s.py
@@ -3,9 +3,9 @@
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildPlan, BuildProducts
 from torii.hdl.ir                       import Fragment
-from torii.platform.resources           import (
-	ButtonResources, DirectUSBResource, LEDResources, SDCardResources, SDRAMResource, SPIResource, UARTResource
-)
+from torii.platform.resources.interface import DirectUSBResource, SPIResource, UARTResource
+from torii.platform.resources.memory    import SDCardResources, SDRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -57,8 +57,9 @@ class _ULX3SPlatform(ECP5Platform):
 			clk = 'J1', cmd = 'J3', dat0 = 'K2', dat1 = 'K1', dat2 = 'H2', dat3 = 'H1',
 			attrs = Attrs(IO_TYPE = 'LVCMOS33', SLEW = 'FAST')
 		),
-		# TODO(aki): Replace with SPIFlashResource
-		# SPI Flash clock is accessed via USR_MCLK instance.
+		# XXX(aki):
+		# We can't replace this with `SPIFlashResource` because it needs a `clk` signal
+		# And the SPI Clock needs to be done via the `USRMCLK` block in the ECP5.
 		Resource(
 			'spi_flash', 0,
 			Subsignal('cs', PinsN('R2', dir = 'o')),
@@ -108,6 +109,7 @@ class _ULX3SPlatform(ECP5Platform):
 		Resource('diff_gpio', 2, DiffPairs('A9', 'B10'), Attrs(IO_TYPE = 'LVCMOS33')),
 		Resource('diff_gpio', 3, DiffPairs('B9', 'C10'),  Attrs(IO_TYPE = 'LVCMOS33')),
 		# HDMI (only TX, due to the top bank of ECP5 only supporting diff. outputs)
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi', 0,
 			Subsignal(

--- a/torii_boards/lattice/ecp5/versa_ecp5.py
+++ b/torii_boards/lattice/ecp5/versa_ecp5.py
@@ -4,7 +4,9 @@ from textwrap                           import dedent
 
 from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
 from torii.build.run                    import BuildProducts
-from torii.platform.resources           import LEDResources, SPIFlashResources, SwitchResources, UARTResource
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ecp5 import ECP5Platform
 
 __all__ = (
@@ -72,7 +74,7 @@ class VersaECP5Platform(ECP5Platform):
 		Resource(
 			'eth_clk125_pll', 0, Pins('U16', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		), # NC by default
-		# TODO(aki): Replace with EthernetResource
+		# TODO(aki): Replace with `EthernetResource` when it has `rst` signal support
 		Resource(
 			'eth_rgmii', 0,
 			Subsignal('rst', PinsN('U17', dir = 'o')),
@@ -86,6 +88,7 @@ class VersaECP5Platform(ECP5Platform):
 			Subsignal('rx_data', Pins('T20 U20 T19 R18', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS25')
 		),
+		# TODO(aki): Replace with `EthernetResource` when it has SGMII support
 		Resource(
 			'eth_sgmii', 0,
 			Subsignal('rst', PinsN('U17', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
@@ -100,6 +103,7 @@ class VersaECP5Platform(ECP5Platform):
 		Resource(
 			'eth_clk125_pll', 1, Pins('C18', dir = 'i'), Clock(125e6), Attrs(IO_TYPE = 'LVCMOS25')
 		), # NC by default
+		# TODO(aki): Replace with `EthernetResource` when it has `rst` signal support
 		Resource(
 			'eth_rgmii', 1,
 			Subsignal('rst', PinsN('F20', dir = 'o')),
@@ -113,6 +117,7 @@ class VersaECP5Platform(ECP5Platform):
 			Subsignal('rx_data', Pins('G18 G16 H18 H17', dir = 'i')),
 			Attrs(IO_TYPE = 'LVCMOS25')
 		),
+		# TODO(aki): Replace with `EthernetResource` when it has SGMII support
 		Resource(
 			'eth_sgmii', 1,
 			Subsignal('rst', PinsN('F20', dir = 'o'), Attrs(IO_TYPE = 'LVCMOS25')),
@@ -121,6 +126,7 @@ class VersaECP5Platform(ECP5Platform):
 			Subsignal('tx', DiffPairs('W17', 'W18', dir = 'o')),
 			Subsignal('rx', DiffPairs('Y16', 'Y17', dir = 'i')),
 		),
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('N4', dir = 'o')),

--- a/torii_boards/lattice/ice40/blackice.py
+++ b/torii_boards/lattice/ice40/blackice.py
@@ -2,9 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import (
-	ButtonResources, LEDResources, SRAMResource, SwitchResources, UARTResource
-)
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SRAMResource
+from torii.platform.resources.user       import ButtonResources, LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/blackice_ii.py
+++ b/torii_boards/lattice/ice40/blackice_ii.py
@@ -2,9 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import (
-	ButtonResources, LEDResources, SRAMResource, SwitchResources, UARTResource
-)
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SRAMResource
+from torii.platform.resources.user       import ButtonResources, LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/fomu_hacker.py
+++ b/torii_boards/lattice/ice40/fomu_hacker.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import DirectUSBResource, LEDResources, RGBLEDResource, SPIFlashResources
+from torii.platform.resources.interface  import DirectUSBResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources, RGBLEDResource
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/fomu_pvt.py
+++ b/torii_boards/lattice/ice40/fomu_pvt.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import DirectUSBResource, LEDResources, RGBLEDResource, SPIFlashResources
+from torii.platform.resources.interface  import DirectUSBResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import ButtonResources, LEDResources, RGBLEDResource
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (
@@ -38,10 +40,7 @@ class FomuPVTPlatform(ICE40Platform):
 			cs_n = 'C1', clk = 'D1', copi = 'F1', cipo = 'E1',
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS'),
 		),
-		Resource('touch', 0, Pins('E4')),
-		Resource('touch', 1, Pins('D5')),
-		Resource('touch', 2, Pins('E5')),
-		Resource('touch', 3, Pins('F5')),
+		*ButtonResources('touch', pins = 'E4 D5 E5 F5'),
 	]
 
 	def toolchain_program(self, products: BuildProducts, name: str) -> None:

--- a/torii_boards/lattice/ice40/ice40_hx1k_blink_evn.py
+++ b/torii_boards/lattice/ice40/ice40_hx1k_blink_evn.py
@@ -2,7 +2,8 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import LEDResources, SPIFlashResources
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/ice40_hx8k_b_evn.py
+++ b/torii_boards/lattice/ice40/ice40_hx8k_b_evn.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import LEDResources, SPIFlashResources, UARTResource
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/ice40_up5k_b_evn.py
+++ b/torii_boards/lattice/ice40/ice40_up5k_b_evn.py
@@ -2,7 +2,8 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, PinsN, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import LEDResources, SPIFlashResources, SwitchResources
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (
@@ -28,6 +29,7 @@ class ICE40UP5KBEVNPlatform(ICE40Platform):
 			pins = '39 40 41', invert = True,
 			attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
+		# Semantic Aliases
 		Resource('led_b', 0, PinsN('39', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_g', 0, PinsN('40', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, PinsN('41', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),

--- a/torii_boards/lattice/ice40/icebreaker.py
+++ b/torii_boards/lattice/ice40/icebreaker.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, PinsN, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import ButtonResources, LEDResources, SPIFlashResources, UARTResource
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/icebreaker_bitsy.py
+++ b/torii_boards/lattice/ice40/icebreaker_bitsy.py
@@ -2,9 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, PinsN, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import (
-	ButtonResources, DirectUSBResource, LEDResources, RGBLEDResource, SPIFlashResources
-)
+from torii.platform.resources.interface  import DirectUSBResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import ButtonResources, LEDResources, RGBLEDResource
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/icestick.py
+++ b/torii_boards/lattice/ice40/icestick.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import IrDAResource, LEDResources, SPIFlashResources, UARTResource
+from torii.platform.resources.interface  import IrDAResource, UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/icesugar.py
+++ b/torii_boards/lattice/ice40/icesugar.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                         import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
+from torii.build                         import Attrs, Clock, Connector, Pins, PinsN, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import LEDResources, SPIFlashResources, SwitchResources, UARTResource
+from torii.platform.resources.interface  import DirectUSBResource, UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources, SwitchResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (
@@ -41,13 +43,9 @@ class ICESugarPlatform(ICE40Platform):
 			cs_n = '16', clk = '15', copi = '14', cipo = '17', wp_n = '12', hold_n = '13',
 			attrs = Attrs(IO_STANDARD = 'LVCMOS33')
 		),
-		# TODO(aki): Replace with DirectUSBResource
-		Resource(
-			'usb', 0,
-			Subsignal('d_p', Pins('10', dir = 'io')),
-			Subsignal('d_n', Pins('9', dir = 'io')),
-			Subsignal('pullup', Pins('11', dir = 'o')),
-			Attrs(IO_STANDARD = 'LVCMOS33')
+		DirectUSBResource(
+			0,
+			d_p = '10', d_n = '9', pullup = '11', attrs = Attrs(IO_STANDARD = 'LVCMOS33')
 		),
 	]
 

--- a/torii_boards/lattice/ice40/icesugar_nano.py
+++ b/torii_boards/lattice/ice40/icesugar_nano.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import LEDResources, SPIFlashResources, UARTResource
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/nandland_go.py
+++ b/torii_boards/lattice/ice40/nandland_go.py
@@ -2,9 +2,10 @@
 
 from torii.build                         import Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import (
-	ButtonResources, Display7SegResource, LEDResources, SPIFlashResources, UARTResource, VGAResource
-)
+from torii.platform.resources.display    import Display7SegResource, VGAResource
+from torii.platform.resources.interface  import UARTResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import ButtonResources, LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/tinyfpga_bx.py
+++ b/torii_boards/lattice/ice40/tinyfpga_bx.py
@@ -2,7 +2,9 @@
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                     import BuildProducts
-from torii.platform.resources            import DirectUSBResource, LEDResources, SPIFlashResources
+from torii.platform.resources.interface  import DirectUSBResource
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/ice40/upduino_v1.py
+++ b/torii_boards/lattice/ice40/upduino_v1.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from torii.build                         import Attrs, Connector, PinsN, Resource
-from torii.platform.resources            import LEDResources, SPIFlashResources
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import LEDResources
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (
@@ -21,6 +22,7 @@ class UpduinoV1Platform(ICE40Platform):
 		*LEDResources(
 			pins = '39 40 41', invert = True, attrs = Attrs(IO_STANDARD = 'SB_LVCMOS')
 		),
+		# Semantic Aliases
 		Resource('led_g', 0, PinsN('39', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_b', 0, PinsN('40', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),
 		Resource('led_r', 0, PinsN('41', dir = 'o'), Attrs(IO_STANDARD = 'SB_LVCMOS')),

--- a/torii_boards/lattice/ice40/upduino_v3.py
+++ b/torii_boards/lattice/ice40/upduino_v3.py
@@ -4,7 +4,8 @@ import os
 import subprocess
 
 from torii.build                         import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources            import RGBLEDResource, SPIFlashResources
+from torii.platform.resources.memory     import SPIFlashResources
+from torii.platform.resources.user       import RGBLEDResource
 from torii.platform.vendor.lattice.ice40 import ICE40Platform
 
 __all__ = (

--- a/torii_boards/lattice/machxo3/machxo3_sk.py
+++ b/torii_boards/lattice/machxo3/machxo3_sk.py
@@ -2,9 +2,9 @@
 
 from torii.build                               import Attrs, Clock, Connector, Pins, Resource
 from torii.build.run                           import BuildProducts
-from torii.platform.resources                  import (
-	ButtonResources, LEDResources, SPIFlashResources, SwitchResources, UARTResource
-)
+from torii.platform.resources.interface        import UARTResource
+from torii.platform.resources.memory           import SPIFlashResources
+from torii.platform.resources.user             import ButtonResources, LEDResources, SwitchResources
 from torii.platform.vendor.lattice.machxo_2_3l import MachXO3LPlatform
 
 __all__ = (

--- a/torii_boards/quicklogic/eos_s3/quickfeather.py
+++ b/torii_boards/quicklogic/eos_s3/quickfeather.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                      import Connector, Pins, Resource, Subsignal
-from torii.build.run                  import BuildProducts
-from torii.platform.resources         import (
-	ButtonResources, DirectUSBResource, I2CResource, RGBLEDResource, SPIResource, UARTResource
-)
-from torii.platform.vendor.quicklogic import QuicklogicPlatform
+from torii.build                        import Connector, Pins, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.interface import DirectUSBResource, I2CResource, SPIResource, UARTResource
+from torii.platform.resources.user      import ButtonResources, RGBLEDResource
+from torii.platform.vendor.quicklogic   import QuicklogicPlatform
 
 __all__ = (
 	'QuickfeatherPlatform',

--- a/torii_boards/xilinx/artix7/alchitry_au.py
+++ b/torii_boards/xilinx/artix7/alchitry_au.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import DDR3Resource, LEDResources
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                     import Attrs, Clock, Connector, Pins, Resource, Subsignal
+from torii.build.run                 import BuildProducts
+from torii.platform.resources.memory import DDR3Resource
+from torii.platform.resources.user   import LEDResources
+from torii.platform.vendor.xilinx    import XilinxPlatform
 
 __all__ = (
 	'AlchitryAuPlatform',
@@ -43,6 +44,7 @@ class AlchitryAuPlatform(XilinxPlatform):
 			pins = 'K13 K12 L14 L13 M16 M14 M12 N16',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# NOTE(aki): I *think* this is a serial port???
 		Resource(
 			'usb', 0,
 			Subsignal('usb_tx', Pins('P16', dir = 'o')),

--- a/torii_boards/xilinx/artix7/arty_a7.py
+++ b/torii_boards/xilinx/artix7/arty_a7.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
+from textwrap                           import dedent
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildPlan, BuildProducts
-from torii.hdl.ir                 import Fragment
-from torii.platform.resources     import (
-	ButtonResources, LEDResources, RGBLEDResource, SPIFlashResources, SPIResource, SwitchResources, UARTResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildPlan, BuildProducts
+from torii.hdl.ir                       import Fragment
+from torii.platform.resources.interface import SPIResource, UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, LEDResources, RGBLEDResource, SwitchResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'ArtyA7_35Platform',
@@ -56,6 +56,7 @@ class _ArtyA7Platform(XilinxPlatform):
 			cs_n = 'L13', clk = 'L16', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('K6', dir = 'o')),
@@ -84,6 +85,7 @@ class _ArtyA7Platform(XilinxPlatform):
 		Resource(
 			'eth_clk50', 0, Pins('G18', dir = 'o'), Clock(50e6), Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `EthernetResource` when more granular attrs are possible
 		Resource(
 			'eth_mii', 0,
 			Subsignal('rst', PinsN('C16', dir = 'o')),
@@ -100,6 +102,7 @@ class _ArtyA7Platform(XilinxPlatform):
 			Subsignal('crs', Pins('G14', dir = 'i')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `EthernetResource` when more granular attrs are possible
 		Resource(
 			'eth_rmii', 0,
 			Subsignal('rst', PinsN('C16', dir = 'o')),

--- a/torii_boards/xilinx/artix7/cmod_a7.py
+++ b/torii_boards/xilinx/artix7/cmod_a7.py
@@ -2,11 +2,11 @@
 
 import subprocess
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources     import (
-	ButtonResources, LEDResources, RGBLEDResource, SPIFlashResources, SRAMResource, UARTResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SPIFlashResources, SRAMResource
+from torii.platform.resources.user      import ButtonResources, LEDResources, RGBLEDResource
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 '''
 Example Usage:

--- a/torii_boards/xilinx/artix7/mega65.py
+++ b/torii_boards/xilinx/artix7/mega65.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.platform.resources     import I2CResource, LEDResources, SDCardResources, UARTResource, VGADACResource
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.platform.resources.display   import VGADACResource
+from torii.platform.resources.interface import I2CResource, UARTResource
+from torii.platform.resources.memory    import SDCardResources
+from torii.platform.resources.user      import LEDResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'Mega65r3Platform',
@@ -115,6 +118,7 @@ class Mega65r3Platform(XilinxPlatform):
 			],
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi', 0,
 			Subsignal('clk', DiffPairs('W1', 'Y1', dir = 'o')),
@@ -141,11 +145,13 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('sync', Pins('F19', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33'),
 		),
+		# TODO(aki): Replace with `SPIFlashResource` when more granular attrs are possible
 		Resource(
 			'spi_flash', 0,
 			Subsignal('data', Pins('P22 R22 P21 R21', dir = 'io'), Attrs(PULLUP = 'TRUE')),
 			Subsignal('cs', PinsN('T19', dir = 'o')),
 		),
+		# TODO(aki): Replace with `HyperBusResource` when more granular attrs are possible
 		Resource(
 			'hyper_ram', 0,
 			Subsignal('clk', Pins('D22', dir = 'o'), Attrs(SLEW = 'FAST', DRIVE = '16')),
@@ -155,6 +161,7 @@ class Mega65r3Platform(XilinxPlatform):
 			Subsignal('cs', Pins('C22', dir = 'o')),
 			Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'FALSE'),
 		),
+		# TODO(aki): Replace with `EthernetResource` when more granular attrs are possible
 		Resource(
 			'ethernet', 0,
 			Subsignal('led', Pins('R14', dir = 'o')),

--- a/torii_boards/xilinx/artix7/nexys4ddr.py
+++ b/torii_boards/xilinx/artix7/nexys4ddr.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
+from textwrap                           import dedent
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildPlan, BuildProducts
-from torii.hdl.ir                 import Fragment
-from torii.platform.resources     import (
-	Display7SegResource, LEDResources, PS2Resource, RGBLEDResource, SDCardResources,
-	SPIFlashResources, SwitchResources, UARTResource, VGAResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildPlan, BuildProducts
+from torii.hdl.ir                       import Fragment
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import PS2Resource, UARTResource
+from torii.platform.resources.memory    import SDCardResources, SPIFlashResources
+from torii.platform.resources.user      import LEDResources, RGBLEDResource, SwitchResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'Nexys4DDRPlatform',
@@ -128,6 +128,7 @@ class Nexys4DDRPlatform(XilinxPlatform):
 			clk = 'F4', dat = 'B2',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33', PULLUP = 'TRUE')
 		),
+		# TODO(aki): Replace with `EthernetResource` when more granular attrs are possible
 		Resource(
 			'eth', 0,  # LAN8720A
 			Subsignal('mdio', Pins('A9', dir = 'io')),
@@ -147,6 +148,7 @@ class Nexys4DDRPlatform(XilinxPlatform):
 			cs_n = 'L13', clk = 'E9', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M14',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `DDR2Resource` when more granular attrs are possible
 		Resource(
 			'ddr2', 0, # MT47H64M16HR-25:H
 			Subsignal('a', Pins('M4 P4 M6 T1 L3 P5 M2 N1 L4 N5 R2 K5 N6 K3', dir = 'o')),

--- a/torii_boards/xilinx/artix7/te0714_03_50_2I.py
+++ b/torii_boards/xilinx/artix7/te0714_03_50_2I.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources     import LEDResources, SPIFlashResources
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                     import Attrs, Clock, Connector, Pins, Resource
+from torii.platform.resources.memory import SPIFlashResources
+from torii.platform.resources.user   import LEDResources
+from torii.platform.vendor.xilinx    import XilinxPlatform
 
 __all__ = (
 	'TE0714_03_50_2IPlatform',

--- a/torii_boards/xilinx/kintex7/genesys2.py
+++ b/torii_boards/xilinx/kintex7/genesys2.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
-from typing                       import Literal
+from textwrap                           import dedent
+from typing                             import Literal
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildPlan, BuildProducts
-from torii.hdl.ir                 import Fragment
-from torii.platform.resources     import (
-	ButtonResources, I2CResource, LEDResources, SDCardResources, SPIResource,
-	SwitchResources, UARTResource, ULPIResource, VGAResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildPlan, BuildProducts
+from torii.hdl.ir                       import Fragment
+from torii.platform.resources.display   import VGAResource
+from torii.platform.resources.interface import I2CResource, SPIResource, UARTResource, ULPIResource
+from torii.platform.resources.memory    import SDCardResources
+from torii.platform.resources.user      import ButtonResources, LEDResources, SwitchResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'Genesys2Platform',
@@ -84,6 +84,7 @@ class Genesys2Platform(XilinxPlatform):
 			scl = 'AE30', sda = 'AF30',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('AG5', dir = 'o'), Attrs(IOSTANDARD = 'SSTL15')),
@@ -153,6 +154,7 @@ class Genesys2Platform(XilinxPlatform):
 			Subsignal('vbat_en', PinsN('AB22', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),
 			Attrs(IOSTANDARD = 'LVCMOS18')
 		),
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi', 0,  # HDMI TX, connector J4
 			Subsignal('scl', Pins('AF27', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
@@ -165,6 +167,7 @@ class Genesys2Platform(XilinxPlatform):
 			)),
 			Attrs(IOSTANDARD = 'TMDS_33')
 		),
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi', 1,  # HDMI RX, connector J5
 			Subsignal('scl', Pins('AJ28', dir = 'io'), Attrs(IOSTANDARD = 'LVCMOS33')),
@@ -204,6 +207,7 @@ class Genesys2Platform(XilinxPlatform):
 		Resource(
 			'vusb_oc', 0, PinsN('AF16', dir = 'i'), Attrs(IOSTANDARD = 'LVCMOS18')
 		),
+		# TODO(aki): Replace with `EthernetResource` when more granular attrs are possible
 		Resource(
 			'eth_rgmii', 0,
 			Subsignal('rst', PinsN('AH24', dir = 'o'), Attrs(IOSTANDARD = 'LVCMOS33')),

--- a/torii_boards/xilinx/kintex7/kc705.py
+++ b/torii_boards/xilinx/kintex7/kc705.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, DiffPairs, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import LEDResources, UARTResource
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, DiffPairs, Resource
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.user      import LEDResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'KC705Platform',

--- a/torii_boards/xilinx/kintex_us/kcu105.py
+++ b/torii_boards/xilinx/kintex_us/kcu105.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, DiffPairs, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import LEDResources
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                   import Attrs, Clock, DiffPairs, Resource
+from torii.build.run               import BuildProducts
+from torii.platform.resources.user import LEDResources
+from torii.platform.vendor.xilinx  import XilinxPlatform
 
 __all__ = (
 	'KCU105Platform',

--- a/torii_boards/xilinx/spartan3/mercury.py
+++ b/torii_boards/xilinx/spartan3/mercury.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import (
-	Display7SegResource, PS2Resource, SPIFlashResources, SPIResource, SRAMResource, UARTResource, VGAResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.display   import Display7SegResource, VGAResource
+from torii.platform.resources.interface import PS2Resource, SPIResource, UARTResource
+from torii.platform.resources.memory    import SPIFlashResources, SRAMResource
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'MercuryPlatform',

--- a/torii_boards/xilinx/spartan6/numato_mimas.py
+++ b/torii_boards/xilinx/spartan6/numato_mimas.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources     import ButtonResources, LEDResources, SPIFlashResources
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                     import Attrs, Clock, Connector, Pins, Resource
+from torii.platform.resources.memory import SPIFlashResources
+from torii.platform.resources.user   import ButtonResources, LEDResources
+from torii.platform.vendor.xilinx    import XilinxPlatform
 
 __all__ = (
 	'NumatoMimasPlatform',

--- a/torii_boards/xilinx/spartan6/sk_xc6slx9.py
+++ b/torii_boards/xilinx/spartan6/sk_xc6slx9.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources     import SPIFlashResources, SRAMResource
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                     import Attrs, Clock, Connector, Pins, Resource
+from torii.platform.resources.memory import SPIFlashResources, SRAMResource
+from torii.platform.vendor.xilinx    import XilinxPlatform
 
 __all__ = (
 	'SK_XC6SLX9Platform',

--- a/torii_boards/xilinx/spartan7/arty_s7.py
+++ b/torii_boards/xilinx/spartan7/arty_s7.py
@@ -1,15 +1,14 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from textwrap                     import dedent
+from textwrap                           import dedent
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildPlan, BuildProducts
-from torii.hdl.ir                 import Fragment
-from torii.platform.resources     import (
-	ButtonResources, I2CResource, LEDResources, RGBLEDResource, SPIFlashResources, SPIResource,
-	SwitchResources, UARTResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build.run                    import BuildPlan, BuildProducts
+from torii.hdl.ir                       import Fragment
+from torii.platform.resources.interface import I2CResource, SPIResource, UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, LEDResources, RGBLEDResource, SwitchResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'ArtyS7_25Platform',
@@ -52,6 +51,7 @@ class _ArtyS7Platform(XilinxPlatform):
 			cs_n = 'M13', clk = 'D11', copi = 'K17', cipo = 'K18', wp_n = 'L14', hold_n = 'M15',
 			attrs = Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `DDR3Resource` when more granular attrs are possible
 		Resource(
 			'ddr3', 0,
 			Subsignal('rst', PinsN('J6', dir = 'o')),

--- a/torii_boards/xilinx/spartan7/cmod_s7.py
+++ b/torii_boards/xilinx/spartan7/cmod_s7.py
@@ -2,11 +2,11 @@
 
 import subprocess
 
-from torii.build                  import Attrs, Clock, Connector, Pins, Resource
-from torii.platform.resources     import (
-	ButtonResources, LEDResources, RGBLEDResource, SPIFlashResources, UARTResource
-)
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Connector, Pins, Resource
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.memory    import SPIFlashResources
+from torii.platform.resources.user      import ButtonResources, LEDResources, RGBLEDResource
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 '''
 Example Usage:

--- a/torii_boards/xilinx/zynq7/arty_z7.py
+++ b/torii_boards/xilinx/zynq7/arty_z7.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import ButtonResources, LEDResources, RGBLEDResource, SwitchResources
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                   import Attrs, Clock, Connector, DiffPairs, Pins, PinsN, Resource, Subsignal
+from torii.build.run               import BuildProducts
+from torii.platform.resources.user import ButtonResources, LEDResources, RGBLEDResource, SwitchResources
+from torii.platform.vendor.xilinx  import XilinxPlatform
 
 __all__ = (
 	'ArtyZ720Platform',
@@ -55,6 +55,7 @@ class ArtyZ720Platform(XilinxPlatform):
 			Pins('J15', dir = 'io'),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi_rx', 0, # J10
 			Subsignal('cec', Pins('H17', dir = 'io')),
@@ -67,6 +68,7 @@ class ArtyZ720Platform(XilinxPlatform):
 			Subsignal('sda', Pins('U15', dir = 'io')),
 			Attrs(IOSTANDARD = 'LVCMOS33')
 		),
+		# TODO(aki): Replace with `HDMIResource` when merged + released in Torii
 		Resource(
 			'hdmi_tx', 0, # J11
 			Subsignal('cec', Pins('G15', dir = 'io')),

--- a/torii_boards/xilinx/zynq7/ebaz4205.py
+++ b/torii_boards/xilinx/zynq7/ebaz4205.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
-from torii.build                  import Attrs, Clock, Pins, Resource
-from torii.build.run              import BuildProducts
-from torii.platform.resources     import LEDResources, UARTResource
-from torii.platform.vendor.xilinx import XilinxPlatform
+from torii.build                        import Attrs, Clock, Pins, Resource
+from torii.build.run                    import BuildProducts
+from torii.platform.resources.interface import UARTResource
+from torii.platform.resources.user      import LEDResources
+from torii.platform.vendor.xilinx       import XilinxPlatform
 
 __all__ = (
 	'EBAZ4205Platform',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR updates the `torii.platform.resource` imports as well as tries to use existing Torii resources where possible.

There are quite a few instances where the existing resources are not flexible or complete enough to be used, but once they are then we can update them here once again.

After this PR is merged we plan to release `v0.8.1` so we can push out the deprecation warnings, then we can break API for `v1.0.0` after.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii Boards [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii Boards and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.


<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md#ai-usage-policy
