### PR TITLE
Add `dist-docs` and `build-docset` Nox sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
-from os             import getenv
-from pathlib        import Path
-from shutil         import copy
+from os           import getenv
+from pathlib      import Path
+from shutil       import copy, make_archive, rmtree
 
 import nox
-from nox.sessions   import Session
+from nox.sessions import Session
 
 ROOT_DIR  = Path(__file__).parent
 
@@ -126,6 +126,48 @@ def build_docs_multiversion(session: Session) -> None:
 			session.warn(f'Docs for {latest} did not seem to be built, using development docs instead')
 			# Otherwise, link to `main`
 			latest_link.symlink_to(docs_dev)
+
+@nox.session(name = 'build-docset', reuse_venv = True)
+def build_docset(session: Session) -> None:
+	DOCS_DIR = BUILD_DIR / 'docs'
+
+	# XXX(aki): We can't `session.notify` here because we need the docs first
+	build_docs(session)
+
+	session.install('doc2dash')
+
+	# Get the Torii Boards version
+	torii_boards_version: str = session.run(
+		'python', '-c', 'import torii_boards;print(torii_boards.__version__)',
+		silent = True
+	)
+
+	with session.chdir(BUILD_DIR):
+		# If the docset is already built, shred it because `doc2dash` won't overwrite it
+		if (BUILD_DIR / 'Torii_Boards.docset').exists():
+			rmtree(BUILD_DIR / 'Torii_Boards.docset')
+
+		# Build the docset
+		session.run(
+			'doc2dash', '-n', 'Torii_Boards', '-j', '--full-text-search', 'on', str(DOCS_DIR)
+		)
+
+		# Compress it
+		make_archive(f'torii_boards-{torii_boards_version.strip()}-docset', 'zip', BUILD_DIR, 'Torii_Boards.docset')
+
+@nox.session(name = 'dist-docs', reuse_venv = True)
+def dist_docs(session: Session) -> None:
+	# XXX(aki): We can't `session.notify` here because we need the docs first
+	build_docs(session)
+
+	# Get the Torii Boards version
+	torii_boards_version: str = session.run(
+		'python', '-c', 'import torii_boards;print(torii_boards.__version__)',
+		silent = True
+	)
+
+	with session.chdir(BUILD_DIR):
+		make_archive(f'torii_boards-{torii_boards_version.strip()}-docs', 'zip', BUILD_DIR, 'docs')
 
 @nox.session(name = 'linkcheck-docs', reuse_venv = True)
 def linkcheck_docs(session: Session) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Filling out this template is mandatory -->

<!-- =========================== -->
<!-- DO NOT EDIT ABOVE THIS LINE -->
<!-- =========================== -->

## Detailed Description

This PR adds 2 new Nox sessions, the first is `dist-docs` which just simply builds the documentation and produces a versioned Zip archive. The second being `build-docset` which builds a [docset] of the Torii Boards documentation for viewing in something like [Zeal].

This means we can now produce documentation sets that can be used offline.

# Pull Request Checklist
<!-- These are *required* -->

* [ ] This is an API breaking change. <!-- Check this box only if this is a breaking change -->
* [x] I agree to follow the Torii Boards [Code Of Conduct].
* [x] I've read and understand the [Contribution Guidelines] and [AI Usage Policy] for Torii Boards and agree to follow them.
* [x] I've tested this to the best of my ability.
* [x] I've documented the change to the best my ability.

<!-- =========================== -->
<!-- DO NOT EDIT BELOW THIS LINE -->
<!-- =========================== -->

[Code Of Conduct]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CODE_OF_CONDUCT.md
[Contribution Guidelines]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md
[AI Usage Policy]: https://github.com/shrine-maiden-heavy-industries/torii-boards/blob/main/CONTRIBUTING.md#ai-usage-policy
[docset]: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/Documentation_Sets/010-Overview_of_Documentation_Sets/docset_overview.html#//apple_ref/doc/uid/TP40005266-CH13-SW6
[Zeal]: https://zealdocs.org/